### PR TITLE
move from jaypipes -> runmachine-io

### DIFF
--- a/cmd/runm-metadata/Dockerfile
+++ b/cmd/runm-metadata/Dockerfile
@@ -1,8 +1,8 @@
 # We use a multi-stage build, so we require Docker >=17.05 to build these
 # example images
 FROM golang:alpine as builder
-COPY . /go/src/github.com/jaypipes/runmachine
-WORKDIR /go/src/github.com/jaypipes/runmachine/cmd/runm-metadata
+COPY . /go/src/github.com/runmachine-io/runmachine
+WORKDIR /go/src/github.com/runmachine-io/runmachine/cmd/runm-metadata
 RUN apk --no-cache add -t git \
     && apk --no-cache add ca-certificates \
     && go get github.com/golang/dep/cmd/dep \

--- a/cmd/runm-metadata/main.go
+++ b/cmd/runm-metadata/main.go
@@ -8,11 +8,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/jaypipes/runmachine/pkg/metadata"
-	"github.com/jaypipes/runmachine/pkg/metadata/config"
-	pb "github.com/jaypipes/runmachine/proto"
+	"github.com/runmachine-io/runmachine/pkg/metadata"
+	"github.com/runmachine-io/runmachine/pkg/metadata/config"
+	pb "github.com/runmachine-io/runmachine/proto"
 
-	"github.com/jaypipes/runmachine/pkg/logging"
+	"github.com/runmachine-io/runmachine/pkg/logging"
 )
 
 func main() {

--- a/cmd/runm/Dockerfile
+++ b/cmd/runm/Dockerfile
@@ -1,8 +1,8 @@
 # We use a multi-stage build, so we require Docker >=17.05 to build these
 # example images
 FROM golang:alpine as builder
-COPY . /go/src/github.com/jaypipes/runmachine
-WORKDIR /go/src/github.com/jaypipes/runmachine/cmd/runm
+COPY . /go/src/github.com/runmachine-io/runmachine
+WORKDIR /go/src/github.com/runmachine-io/runmachine/cmd/runm
 RUN apk --no-cache add -t git \
     && apk --no-cache add ca-certificates \
     && go get github.com/golang/dep/cmd/dep \

--- a/cmd/runm/commands/property_schema_list.go
+++ b/cmd/runm/commands/property_schema_list.go
@@ -8,8 +8,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	pb "github.com/jaypipes/runmachine/proto"
 	"github.com/olekukonko/tablewriter"
+	pb "github.com/runmachine-io/runmachine/proto"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/runm/main.go
+++ b/cmd/runm/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jaypipes/runmachine/cmd/runm/commands"
+	"github.com/runmachine-io/runmachine/cmd/runm/commands"
 )
 
 func main() {

--- a/pkg/metadata/config/config.go
+++ b/pkg/metadata/config/config.go
@@ -13,7 +13,7 @@ import (
 	flag "github.com/ogier/pflag"
 
 	"github.com/jaypipes/envutil"
-	"github.com/jaypipes/runmachine/pkg/util"
+	"github.com/runmachine-io/runmachine/pkg/util"
 )
 
 const (

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -3,7 +3,7 @@ package metadata
 import (
 	"context"
 
-	pb "github.com/jaypipes/runmachine/proto"
+	pb "github.com/runmachine-io/runmachine/proto"
 )
 
 func (s *Server) ObjectDelete(

--- a/pkg/metadata/property.go
+++ b/pkg/metadata/property.go
@@ -3,7 +3,7 @@ package metadata
 import (
 	"context"
 
-	pb "github.com/jaypipes/runmachine/proto"
+	pb "github.com/runmachine-io/runmachine/proto"
 )
 
 func (s *Server) PropertySchemaDelete(

--- a/pkg/metadata/server.go
+++ b/pkg/metadata/server.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/jaypipes/gsr"
 
-	"github.com/jaypipes/runmachine/pkg/logging"
-	"github.com/jaypipes/runmachine/pkg/metadata/config"
-	"github.com/jaypipes/runmachine/pkg/metadata/storage"
+	"github.com/runmachine-io/runmachine/pkg/logging"
+	"github.com/runmachine-io/runmachine/pkg/metadata/config"
+	"github.com/runmachine-io/runmachine/pkg/metadata/storage"
 )
 
 type Server struct {

--- a/pkg/metadata/storage/connect.go
+++ b/pkg/metadata/storage/connect.go
@@ -9,8 +9,8 @@ import (
 	etcd "github.com/coreos/etcd/clientv3"
 	"google.golang.org/grpc"
 
-	"github.com/jaypipes/runmachine/pkg/logging"
-	"github.com/jaypipes/runmachine/pkg/metadata/config"
+	"github.com/runmachine-io/runmachine/pkg/logging"
+	"github.com/runmachine-io/runmachine/pkg/metadata/config"
 )
 
 // Returns an etcd3 client using an exponential backoff and reconnect strategy.

--- a/pkg/metadata/storage/property.go
+++ b/pkg/metadata/storage/property.go
@@ -4,9 +4,9 @@ import (
 	etcd "github.com/coreos/etcd/clientv3"
 	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
 
-	"github.com/jaypipes/runmachine/pkg/abstract"
-	"github.com/jaypipes/runmachine/pkg/cursor"
-	pb "github.com/jaypipes/runmachine/proto"
+	"github.com/runmachine-io/runmachine/pkg/abstract"
+	"github.com/runmachine-io/runmachine/pkg/cursor"
+	pb "github.com/runmachine-io/runmachine/proto"
 )
 
 const (

--- a/pkg/metadata/storage/store.go
+++ b/pkg/metadata/storage/store.go
@@ -6,8 +6,8 @@ import (
 	etcd "github.com/coreos/etcd/clientv3"
 	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
 
-	"github.com/jaypipes/runmachine/pkg/logging"
-	"github.com/jaypipes/runmachine/pkg/metadata/config"
+	"github.com/runmachine-io/runmachine/pkg/logging"
+	"github.com/runmachine-io/runmachine/pkg/metadata/config"
 )
 
 const (


### PR DESCRIPTION
Simply changes package paths to the new GH organization instead of my
personal repo.