### PR TITLE
specify claim config in resource PoC tests

### DIFF
--- a/tests/poc/resource/README.md
+++ b/tests/poc/resource/README.md
@@ -1,0 +1,100 @@
+# runm-resource data model testing
+
+This directory contains Python and SQL code that tests the database schema and
+modeling for the `runm-resource` service. The `runm-resource` service is a
+critical component in `runmachine` and is responsible for resource accounting,
+scheduling/placement and resource reservation. Therefore, we want to ensure
+that the underlying database modeling is sound and that the queries required by
+the service are performant, utilize indexes appropriately, and work well at
+varying scales (of deployment size).
+
+We test the data model and schema in Python because it's quick and easy to
+prototype things and run tests. We're not interested in comparing the raw speed
+of Golang versus Python. Rather, we're simply interested in quickly loading up
+a DB with varying scale scenarios, running claim and placement tests aghainst
+that DB, and tearing it all down.
+
+We use MySQL for the tests, though there's nothing preventing the use of
+PostgreSQL or another DB system. Again, we're not comparing MySQL vs
+PostgreSQL. We're only interested in how the data model stands up under varying
+query scenarios and deployment scales.
+
+## How to use this code
+
+**PREREQUISITES**: Install MySQL on your test machine. Make a note of the root
+database password.
+
+First, create a `virtualenv` so that you don't need to worry about Python
+package dependencies on your local testing machine:
+
+```
+cd $ROOT_DIR/tests/poc
+virtualenv .venv
+```
+
+Then activate your virtualenv and export your local database :
+
+```
+source .venv/bin/activate
+```
+
+Install the Python package dependencies into your virtualenv:
+
+```
+pip install -r requirements.txt
+```
+
+Export the password for the `root` user of your database:
+
+```
+export RUNM_TEST_RESOURCE_DB_PASS=foo
+```
+
+Run the resource data model test:
+
+```
+python resource/run.py --reset
+```
+
+**NOTE**: The `--reset` argument reloads the resource database. You only need
+to run with `--reset` when you want to load (or re-load) a certain deployment
+configuration (the `--deployment-config` CLI option can be used to switch
+deployment configuration profiles)
+
+The tool will load the database up with the deployment configuration described
+by a YAML file and selected with the `--deployment-config` CLI option and
+execute a single claim request described by a YAML file and selected with the
+`--claim-config` CLI option.
+
+Example output:
+
+```
+(.venv) [jaypipes@uberbox poc]$ python resource/run.py --reset \
+> --deployment-config 10k-shared-compute \
+> --claim-config 1cpu-64M-10G
+loading deployment config ... ok
+resetting resource PoC database ... ok
+creating object types ... ok
+creating provider types ... ok
+creating resource classes ... ok
+creating consumer types ... ok
+creating capabilities ... ok
+creating distance types ... ok
+creating distances ... ok
+creating partitions ... ok
+creating provider groups ... ok
+caching provider group internal IDs ... ok
+caching resource class and capability internal IDs ... ok
+caching partition, distance type and distance internal IDs ... ok
+creating providers ... ok
+loading claim config ... ok
+Found 50 providers with capacity for 1000000000 runm.block_storage
+Found 50 providers with capacity for 67108864 runm.memory
+Found 50 providers with capacity for 1 runm.cpu.shared
+Claim(allocation=
+    Allocation(consumer=Consumer(name=instance0,uuid=e8495d7172714de0a0106e6a4c4927f7),claim_time=1540490434,release_time=9223372036854775807,items=[
+        AllocationItem(provider=Provider(uuid=00af7f6b00224f81acea148e3318fe34),resource_class=runm.block_storage,used=1000000000),
+        AllocationItem(provider=Provider(uuid=00af7f6b00224f81acea148e3318fe34),resource_class=runm.memory,used=67108864),
+        AllocationItem(provider=Provider(uuid=00af7f6b00224f81acea148e3318fe34),resource_class=runm.cpu.shared,used=1)]))
+
+```

--- a/tests/poc/resource/claim-configs/1cpu-64M-10G.yaml
+++ b/tests/poc/resource/claim-configs/1cpu-64M-10G.yaml
@@ -1,0 +1,13 @@
+request_groups:
+  - resources:
+      runm.cpu.shared:
+        min: 1
+        max: 1
+      runm.memory:
+        # 64M
+        min: 67108864
+        max: 67108864
+      runm.block_storage:
+        # 10GB
+        min: 1000000000
+        max: 1000000000

--- a/tests/poc/resource/claim.py
+++ b/tests/poc/resource/claim.py
@@ -7,9 +7,10 @@ import resource_models
 
 
 class ResourceConstraint(object):
-    def __init__(self, resource_class, amount):
+    def __init__(self, resource_class, min_amount, max_amount):
         self.resource_class = resource_class
-        self.amount = amount
+        self.min_amount = min_amount
+        self.max_amount = max_amount
 
 
 class CapabilityConstraint(object):
@@ -137,7 +138,7 @@ def _process_claim_request_group(ctx, claim_request, group_index):
         alloc_item = resource_models.AllocationItem(
             resource_class=rc_constraint.resource_class,
             provider=chosen,
-            used=rc_constraint.amount,
+            used=rc_constraint.max_amount,
         )
         alloc_items.append(alloc_item)
     return alloc_items
@@ -243,7 +244,7 @@ def _process_resource_constraints(ctx, claim_time, release_time,
             return {}
 
         print "Found %d providers with capacity for %d %s" % (
-            len(providers), rc_constraint.amount, rc_constraint.resource_class
+            len(providers), rc_constraint.max_amount, rc_constraint.resource_class
         )
         rc_provider_ids = set(p.id for p in providers)
         if matched_provs:
@@ -364,7 +365,7 @@ def _find_providers_with_resource(ctx, claim_time, release_time,
             inv_tbl.c.resource_class_id == rc_id,
             ((inv_tbl.c.total - inv_tbl.c.reserved)
                 * inv_tbl.c.allocation_ratio)
-            >= (resource_constraint.amount + func.coalesce(usage_subq.c.total_used, 0)))
+            >= (resource_constraint.max_amount + func.coalesce(usage_subq.c.total_used, 0)))
     ).limit(50)
     sess = resource_models.get_session()
     return [

--- a/tests/poc/resource/claim_config.py
+++ b/tests/poc/resource/claim_config.py
@@ -1,0 +1,46 @@
+# An inventory profile describes the providers, their inventory, traits and
+# aggregate relationships for an entire load scenario
+
+import os
+
+import yaml
+
+import claim
+
+
+class ClaimConfig(object):
+    def __init__(self, fp):
+        """Loads the claim configuration from a supplied filepath to a YAML
+        file.
+        """
+        if not fp.endswith('.yaml'):
+            fp = fp + '.yaml'
+        if not os.path.exists(fp):
+            raise RuntimeError("Unable to load claim configuration %s. "
+                               "File does not exist." % fp)
+
+        with open(fp, 'rb') as f:
+            try:
+                config_dict = yaml.load(f)
+            except yaml.YAMLError as err:
+                raise RuntimeError("Unable to load claim configuration "
+                                   "%s. Problem parsing file: %s." % (fp, err))
+        self._load_claim_request_groups(config_dict)
+
+    def _load_claim_request_groups(self, config_data):
+        req_groups = []
+        for request_group in config_data['request_groups']:
+            res_constraints = []
+            for rc_name, res_request in request_group['resources'].items():
+                if 'min' not in res_request and 'max' not in res_request:
+                    raise ValueError("Either min or max must be set for "
+                                     "resource request group for %s" % rc_name)
+                min_amount = res_request.get('min', res_request.get('max'))
+                max_amount = res_request.get('max', res_request.get('min'))
+                res_constraint = claim.ResourceConstraint(
+                    rc_name, min_amount, max_amount)
+                res_constraints.append(res_constraint)
+            req_group = claim.ClaimRequestGroup(
+                resource_constraints=res_constraints)
+            req_groups.append(req_group)
+        self.claim_request_groups = req_groups

--- a/tests/poc/resource/resource_schema.sql
+++ b/tests/poc/resource/resource_schema.sql
@@ -158,7 +158,7 @@ CREATE TABLE allocations (
 , consumer_id BIGINT NOT NULL
 , claim_time BIGINT NOT NULL
 , release_time BIGINT NOT NULL
-, INDEX ix_consumer (consumer_id)
+, INDEX ix_consumer_window (consumer_id, claim_time, release_time)
 , INDEX ix_window (claim_time, release_time)
 ) CHARACTER SET latin1 COLLATE latin1_bin;
 

--- a/tests/poc/resource/run.py
+++ b/tests/poc/resource/run.py
@@ -9,6 +9,7 @@ import time
 
 import claim
 import load
+import claim_config
 import deployment_config
 import resource_models
 
@@ -17,6 +18,10 @@ _DEPLOYMENT_CONFIGS_DIR = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'deployment-configs',
 )
 _DEFAULT_DEPLOYMENT_CONFIG = '1k-shared-compute'
+_CLAIM_CONFIGS_DIR = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), 'claim-configs',
+)
+_DEFAULT_CLAIM_CONFIG = '1cpu-64M-10G'
 
 
 class RunContext(object):
@@ -40,44 +45,48 @@ class RunContext(object):
 
 
 def find_claims(ctx):
+    ctx.status("loading claim config")
+    fp = os.path.join(_CLAIM_CONFIGS_DIR, args.claim_config)
+    ctx.claim_config = claim_config.ClaimConfig(fp)
+    ctx.status_ok()
     consumer = resource_models.Consumer(name="instance0")
     cap_constraints = [
         claim.CapabilityConstraint(require_caps=["hw.cpu.x86.avx2"])
     ]
-    resource_constraints = [
-        claim.ResourceConstraint("runm.cpu.shared", 2),
-        claim.ResourceConstraint("runm.memory", 128*1000*1000),
-        claim.ResourceConstraint("runm.block_storage", 10*1000*1000*1000),
-    ]
-    crg0 = claim.ClaimRequestGroup(
-        resource_constraints=resource_constraints,
-        capability_constraints=cap_constraints,
-    )
-    request_groups = [
-        crg0,
-    ]
     claim_time = datetime.datetime.utcnow()
     claim_time = int(time.mktime(claim_time.timetuple()))
     release_time = sys.maxint
-    cr = claim.ClaimRequest(consumer, request_groups, claim_time, release_time)
+    cr = claim.ClaimRequest(
+        consumer, ctx.claim_config.claim_request_groups, claim_time,
+        release_time)
     claims = claim.process_claim_request(ctx, cr)
     for c in claims:
         print c
 
 
 def setup_opts(parser):
+    parser.add_argument('--reset', action='store_true',
+                        default=False, help="Reset and reload the database.")
+
     deployment_configs = []
     for fn in os.listdir(_DEPLOYMENT_CONFIGS_DIR):
         fp = os.path.join(_DEPLOYMENT_CONFIGS_DIR, fn)
         if os.path.isfile(fp) and fn.endswith('.yaml'):
             deployment_configs.append(fn[0:len(fn) - 5])
 
-    parser.add_argument('--reset', action='store_true',
-                        default=False, help="Reset and reload the database.")
     parser.add_argument('--deployment-config',
                         choices=deployment_configs,
                         default=_DEFAULT_DEPLOYMENT_CONFIG,
                         help="Deployment configuration to use.")
+    claim_configs = []
+    for fn in os.listdir(_CLAIM_CONFIGS_DIR):
+        fp = os.path.join(_CLAIM_CONFIGS_DIR, fn)
+        if os.path.isfile(fp) and fn.endswith('.yaml'):
+            claim_configs.append(fn[0:len(fn) - 5])
+    parser.add_argument('--claim-config',
+                        choices=claim_configs,
+                        default=_DEFAULT_CLAIM_CONFIG,
+                        help="Claim configuration to use.")
 
 
 def main(ctx):


### PR DESCRIPTION
Adds the ability to specify a claim configuration (stored in a YAML doc)
for the runm-resource data model testing framework. There was already
the ability to specify a deployment configuration that described the
scale and profile of a deployment (racks, rows, sites, etc) and this
patch adds the equivalent functionality for specifying the details of a
claim request for resources.

Issue #2