### PR TITLE
Support resource-specific capability constraints

### DIFF
--- a/proto/defs/constraint.proto
+++ b/proto/defs/constraint.proto
@@ -21,20 +21,27 @@ message ProviderGroupConstraint {
 }
 
 message CapabilityConstraint {
-    // All providers involved in the request group must collectively contain
-    // ALL capabilities in this list
+    // All providers involved in the request group or resource constraint must
+    // collectively contain ALL capabilities in this list
     repeated Capability require = 1;
-    // No provider involved in the request group may contain ANY of the capabilities
-    // in this list
+    // No provider involved in the request group or resource constraint may
+    // contain ANY of the capabilities in this list
     repeated Capability forbid = 2;
-    // At least one provider involved in the request group must contain AT
-    // LEAST ONE of the capabilities in this list
+    // At least one provider involved in the request group or resource
+    // constraint must contain AT LEAST ONE of the capabilities in this list
     repeated Capability any = 3;
 }
 
 message ResourceConstraint {
     ResourceClass resource_class = 1;
     uint64 amount = 2;
+    // Providers having a matching amount of resources available to meet this
+    // constraint must also match these capability constraints. This is a way
+    // to have specific capability constraints apply to the provider of a
+    // specific resource -- e.g. requiring that the provider of a
+    // runm.cpu.dedicated resource have the AVX2 x86 instruction set extension
+    // capability associated with it.
+    CapabilityConstraint capability_constraint = 50;
 }
 
 message PropertyConstraint {

--- a/tests/poc/resource/claim-configs/1cpu-64M-10G-resource-caps.yaml
+++ b/tests/poc/resource/claim-configs/1cpu-64M-10G-resource-caps.yaml
@@ -1,0 +1,16 @@
+request_groups:
+  - resources:
+      runm.cpu.shared:
+        min: 1
+        max: 1
+        capabilities:
+          require:
+            - hw.cpu.x86.avx2
+      runm.memory:
+        # 64M
+        min: 67108864
+        max: 67108864
+      runm.block_storage:
+        # 10GB
+        min: 1000000000
+        max: 1000000000

--- a/tests/poc/resource/claim_config.py
+++ b/tests/poc/resource/claim_config.py
@@ -27,20 +27,76 @@ class ClaimConfig(object):
                                    "%s. Problem parsing file: %s." % (fp, err))
         self._load_claim_request_groups(config_dict)
 
+    def _process_capability_constraints(self, block):
+        constraints = []
+        for caps in block:
+            constraints.append(self._process_capability_constraint(caps))
+        return constraints
+
+    def _process_capability_constraint(self, block):
+        # There are three kinds of capability constraints.
+        #
+        # A list of capability names under a 'require' key indicates the
+        # AND'd set of required capabilities that the set of providers
+        # meeting the resource constraints must have.
+        #
+        # A list of capability names under a 'forbid' key indicates the
+        # capabilities that must not be present in any of the providers
+        # meeting the resource constraints.
+        #
+        # A list of capability names under an 'any' key indicates the
+        # providers meeting the resource constraints must have at least one
+        # of the list of capabilities.
+        require_caps = block.get('require')
+        forbid_caps = block.get('forbid')
+        any_caps = block.get('any')
+        constraint = claim.CapabilityConstraint(
+            require_caps=require_caps,
+            forbid_caps=forbid_caps,
+            any_caps=any_caps)
+        return constraint
+
+    def _process_resource_constraints(self, block):
+        constraints = []
+        for rc_name, res_request in block.items():
+            if 'min' not in res_request and 'max' not in res_request:
+                raise ValueError("Either min or max must be set for "
+                                 "resource request group for %s" % rc_name)
+            min_amount = res_request.get('min', res_request.get('max'))
+            max_amount = res_request.get('max', res_request.get('min'))
+
+            # Optional resource-specific capability constraint may be
+            # associated with this resource
+            cap_constraint = None
+            if 'capabilities' in res_request:
+                cap_constraint = self._process_capability_constraint(
+                    res_request['capabilities'])
+
+            constraint = claim.ResourceConstraint(
+                rc_name, min_amount, max_amount,
+                capability_constraint=cap_constraint)
+            constraints.append(constraint)
+        return constraints
+
     def _load_claim_request_groups(self, config_data):
         req_groups = []
         for request_group in config_data['request_groups']:
-            res_constraints = []
-            for rc_name, res_request in request_group['resources'].items():
-                if 'min' not in res_request and 'max' not in res_request:
-                    raise ValueError("Either min or max must be set for "
-                                     "resource request group for %s" % rc_name)
-                min_amount = res_request.get('min', res_request.get('max'))
-                max_amount = res_request.get('max', res_request.get('min'))
-                res_constraint = claim.ResourceConstraint(
-                    rc_name, min_amount, max_amount)
-                res_constraints.append(res_constraint)
+            # Handle the resource constraints, which are defined in a
+            # 'resources' key in the request_group object
+            res_constraints = self._process_resource_constraints(
+                request_group['resources'])
+
+            # Capabilities constraints that are under the 'capabilities' key of
+            # the request group object apply to all the providers that match
+            # for the group
+            cap_constraints = None
+            if 'capabilities' in request_group:
+                cap_constraints = self._process_capability_constraints(
+                    request_group['capabilities'])
+
             req_group = claim.ClaimRequestGroup(
-                resource_constraints=res_constraints)
+                resource_constraints=res_constraints,
+                capability_constraints=cap_constraints)
             req_groups.append(req_group)
+
         self.claim_request_groups = req_groups

--- a/tests/poc/resource/run.py
+++ b/tests/poc/resource/run.py
@@ -50,9 +50,6 @@ def find_claims(ctx):
     ctx.claim_config = claim_config.ClaimConfig(fp)
     ctx.status_ok()
     consumer = resource_models.Consumer(name="instance0")
-    cap_constraints = [
-        claim.CapabilityConstraint(require_caps=["hw.cpu.x86.avx2"])
-    ]
     claim_time = datetime.datetime.utcnow()
     claim_time = int(time.mktime(claim_time.timetuple()))
     release_time = sys.maxint


### PR DESCRIPTION
Adds SQL queries to handle different capability constraints on a
specific resource and the ability to specify a resource-specific
capability constraint in the claim-config YAML files.

Issue #5
Issue #2