### PR TITLE
docs for proto/defs, partitioning principles, and resource claiming

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,21 @@ No API extensions. No custom API resources.
 
 * Partitioning
 
-TODO
+To support highly-distributed hardware environments with many physical sites,
+`runmachine` is designed from the beginning to be a shard-aware system. In
+other words, the data housed in a particular installation of `runmachine` is
+*always* contained in a unique partition, and data is stored in backend storage
+systems along with that partitioning key.
+
+Having this partitioning key stored in backend storage means that two
+installations of `runmachine` can have identically-named objects (such as
+providers named `site1.row1.rack1.node1`) and both of these `runmachine`
+systems can share data with the other and handle each other's data without
+worrying about violating uniqueness constraints within their own installation.
+
+This enables many use cases, including federation (the ability for users of two
+unique `runmachine` installations to operate on the other), data export/import
+scenarios, and common "reseller" setups.
 
 ### Project scope
 
@@ -84,7 +98,27 @@ hardware in an organization.
 
 #### Resource claims, reservations and scheduling
 
-TODO
+The natural counterpart to inventory management functionality is the ability
+for users to consume that inventory in a controlled manner. Therefore, it is
+essential that `runmachine` provide robust resource reservation and scheduling
+along with transactionally safe resource claiming across the known set of
+inventory.
+
+In addition to an accurate view of the system's capacity, a good scheduling and
+reservation system **must** have deep knowledge of the following in order to
+make accurate and reliable placement decisions:
+
+* capabilities/features of the providers of inventory
+* how providers are grouped
+* the relative distance between providers (important to satisfy affinity and
+  anti-affinity constraints)
+
+Furthermore, a reliable placement engine **must** be the system that handles
+the atomic consumption of resources against the known system inventory. It is
+*not* possible to build a reliable placement engine unless the resource-claim
+process is fully owned and guaranteed by the placement engine itself. Too many
+race conditions occur and too much system flakiness is observed when outside
+agents are allowed to control all or part of the resource-claim process.
 
 #### Structure object metadata and tagging
 

--- a/proto/defs/README.md
+++ b/proto/defs/README.md
@@ -1,0 +1,35 @@
+# Object models and service gRPC APIs
+
+This directory contains the [Google Protocol
+Buffer](https://developers.google.com/protocol-buffers/) files that define the
+objects in the `runmachine` system as well as the
+[gRPC](https://grpc.io://grpc.io/) APIs for each service component of
+`runmachine`.
+
+## Objects
+
+Object definition `.proto` files describe some concept within `runmachine`.
+
+If you're wondering about a particular term or concept in `runmachine`, a good
+way to learn about that concept is to examine the object definition file for
+the concept. There are comments within each object definition file that outline
+what the object entails and how it relates to other objects in the system.
+
+For example, if you're curious what a "provider" is, check out the comments in
+the [proto/defs/provider.proto](provider.proto) file.
+
+## Service APIs
+
+`.proto` files that begin with the prefix `service_` define the gRPC service
+APIs for a service component of `runmachine`. For example, the
+[proto/defs/service_resource.proto](service_resource.proto) file describes the
+`runm-resource` service component's interfaces for tracking and claiming
+resources within a `runmachine` system.
+
+## Evolution of object models and gRPC service APIs
+
+**NOTE**: Until we hit a 0.1 milestone, we are not being strict about
+backwards-incompatible object or service API changes. Things are in very fluid
+in these early stages of development. Object models and service APIs are being
+stretched and changed as we prototype the services and, more importantly, how
+clients will interact and use these objects and service APIs.

--- a/proto/defs/README.md
+++ b/proto/defs/README.md
@@ -33,3 +33,29 @@ backwards-incompatible object or service API changes. Things are in very fluid
 in these early stages of development. Object models and service APIs are being
 stretched and changed as we prototype the services and, more importantly, how
 clients will interact and use these objects and service APIs.
+
+## Generating code from Protobuffer definitions files
+
+To generate Golang code files from the object and service definitions in the
+[proto/defs](/) directory, do the following from the root source directory:
+
+```
+make generated
+```
+
+Once this is done, you will find Golang files in the [proto/](../) directory.
+These Golang files may then be used as an importable package in your code, like
+so:
+
+```
+package main
+
+import (
+    "runm_pb" github.com/runmachine-io/runmachine/proto
+)
+
+...
+
+```
+
+**NOTE**: In the future, we'll support more languages than Golang.


### PR DESCRIPTION
* Adds a `proto/defs/README.md` file explaining what's in that directory and how to generate Protobuffer code.
* Fills in sections in the main `README.md` about the importance of partitioning as a built-in concept and resource claiming