### PR TITLE
docs on structured metadata and rename resource class

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,19 @@ process is fully owned and guaranteed by the placement engine itself. Too many
 race conditions occur and too much system flakiness is observed when outside
 agents are allowed to control all or part of the resource-claim process.
 
-#### Structure object metadata and tagging
+#### Structured object metadata and tagging
 
-TODO
+Most software needs to provide users (and the system itself) with the ability
+to associate information with objects the system knows about. This information
+is sometimes called "metadata" (data **about** data).
+
+However, when there are no rules to how metadata can be used to catalog objects
+in the system, maintainability and interoperability of the software is
+decreased.
+
+`runmachine` tries to balance the need for robust, full-featured cataloguing of
+objects with these concerns about long-term code maintenance and
+interoperability.
 
 #### Start and stop machine resources
 

--- a/cmd/runm-metadata/README.md
+++ b/cmd/runm-metadata/README.md
@@ -1,0 +1,62 @@
+# runm-metadata
+
+Most software needs to provide users (and the system itself) with the ability
+to associate information with objects the system knows about. This information
+is sometimes called "metadata" (data **about** data).
+
+However, when there are no rules to how metadata can be used to catalog objects
+in the system, maintainability and interoperability of the software is
+decreased.
+
+`runmachine` tries to balance the need for robust, full-featured cataloguing of
+objects with these concerns about long-term code maintenance and
+interoperability. `runm-metadata` is the server component responsible for
+providing this structured object metadata and tagging functionality.
+
+## Background
+
+Software systems are defined by the data they store, how that data is shared
+between users and components, what rules are in place to transform that data
+and decorate it with attributes that provide meaning to users of the system.
+
+Software that doesn't allow either the end user or the system itself to
+adequately describe and prescribe additional meaning to a piece of data is
+software that is doomed to be stuck in a constant struggle to evolve the
+underlying data model with more and more specific attributes about the object
+the data represents.
+
+These new underlying data model attributes inevitably end up being specific to
+a few use cases but irrelevant to a larger number of cases. Each additional
+attribute adds cognitive dissonance to end user, being one more concept the end
+user needs to internalize and commit to memory about a particular object.
+
+On the other hand, software that attempts to provide ultimate flexibility and
+no rules about how metadata is applied to objects tends to devolve into an
+unmaintainable mess.
+
+Users blindly label objects with misspelled attributes.  Groups of users use
+different terms to describe the same thing, making it difficult for external
+systems to correlate and aggregate information. [Tribal knowledge](https://en.wikipedia.org/wiki/Tribal_knowledge)
+flourishes in such situations, and that tribal knowledge ends up destroying the
+maintainability of the system.
+
+A balance is needed between the rigid process of underlying schema migrations
+and the free-for-all world of ungoverned labeling of objects.
+
+The `runm-metadata` service tries to achieve this balance.
+
+## Functionality provided by `runm-metadata`
+
+TODO
+
+### Name to UUID lookups
+
+TODO
+
+### Property schemas
+
+TODO
+
+### Object tagging
+
+TODO

--- a/proto/defs/allocation.proto
+++ b/proto/defs/allocation.proto
@@ -4,13 +4,13 @@ package runm;
 
 import "consumer.proto";
 import "provider.proto";
-import "resource_class.proto";
+import "resource_type.proto";
 
 // An allocation is a record of how many resources a particular consumer is
 // consuming on a set pf provider during a given time interval.
 message AllocationItem {
     Provider provider = 1;
-    ResourceClass resource_class = 2;
+    ResourceType resource_type = 2;
     uint64 used = 3;
 }
 

--- a/proto/defs/constraint.proto
+++ b/proto/defs/constraint.proto
@@ -5,7 +5,7 @@ package runm;
 import "distance.proto";
 import "property.proto";
 import "provider.proto";
-import "resource_class.proto";
+import "resource_type.proto";
 import "capability.proto";
 
 message ProviderGroupConstraint {
@@ -33,7 +33,7 @@ message CapabilityConstraint {
 }
 
 message ResourceConstraint {
-    ResourceClass resource_class = 1;
+    ResourceType resource_type = 1;
     uint64 amount = 2;
     // Providers having a matching amount of resources available to meet this
     // constraint must also match these capability constraints. This is a way

--- a/proto/defs/inventory.proto
+++ b/proto/defs/inventory.proto
@@ -3,13 +3,13 @@ syntax = "proto3";
 package runm;
 
 import "provider.proto";
-import "resource_class.proto";
+import "resource_type.proto";
 
 // An inventory is a record of the capacity of a provider to provide some
 // amount of resources
 message Inventory {
     Provider provider = 1;
-    ResourceClass resource_class = 2;
+    ResourceType resource_type = 2;
     uint64 total = 3;
     uint64 reserved_for_provider = 4;
     uint64 min_unit = 5;

--- a/proto/defs/quota.proto
+++ b/proto/defs/quota.proto
@@ -3,12 +3,12 @@ syntax = "proto3";
 package runm;
 
 import "project.proto";
-import "resource_class.proto";
+import "resource_type.proto";
 
 // The maximum amount of a particular resource that a project is limited to
 // consuming
 message ProjectQuota {
-    ResourceClass resource_class = 1;
+    ResourceType resource_type = 1;
     Project project = 2;
     uint32 amount = 3;
     uint32 generation = 100;

--- a/proto/defs/resource_type.proto
+++ b/proto/defs/resource_type.proto
@@ -6,7 +6,7 @@ import "wrappers.proto";
 
 // A class of consumable resource provided by one or more providers in the
 // system.
-message ResourceClass {
+message ResourceType {
     string code = 1;
     StringValue description = 2;
 }

--- a/proto/defs/service_account.proto
+++ b/proto/defs/service_account.proto
@@ -248,7 +248,7 @@ message ProjectDeleteResponse {
 
 message ProjectQuotasListFilters {
     repeated string projects = 1;
-    repeated string resource_classes = 3;
+    repeated string resource_types = 3;
 }
 
 message ProjectQuotasListRequest {

--- a/proto/defs/service_resource.proto
+++ b/proto/defs/service_resource.proto
@@ -13,7 +13,7 @@ import "inventory.proto";
 import "partition.proto";
 import "project.proto";
 import "provider.proto";
-import "resource_class.proto";
+import "resource_type.proto";
 import "search.proto";
 import "session.proto";
 import "usage.proto";
@@ -24,20 +24,20 @@ import "wrappers.proto";
 // resource providers, the transactional claims of resources, basic scheduling
 // and reservations.
 service RunmResource {
-    // Returns information about a specific resource class
-    rpc resource_class_get(ResourceClassGetRequest) returns (ResourceClass) {}
+    // Returns information about a specific resource type
+    rpc resource_type_get(ResourceTypeGetRequest) returns (ResourceType) {}
 
-    // Deletes one or more resource classes
-    rpc resource_class_delete(ResourceClassDeleteRequest) returns (
-        ResourceClassDeleteResponse) {}
+    // Deletes one or more resource types
+    rpc resource_type_delete(ResourceTypeDeleteRequest) returns (
+        ResourceTypeDeleteResponse) {}
 
-    // Set information about a specific resource class
-    rpc resource_class_set(ResourceClassSetRequest) returns (
-        ResourceClassSetResponse) {}
+    // Set information about a specific resource type
+    rpc resource_type_set(ResourceTypeSetRequest) returns (
+        ResourceTypeSetResponse) {}
 
-    // Returns information about multiple resource classs
-    rpc resource_class_list(ResourceClassListRequest) returns (
-        stream ResourceClass) {}
+    // Returns information about multiple resource types
+    rpc resource_type_list(ResourceTypeListRequest) returns (
+        stream ResourceType) {}
 
     // Returns information about a specific capability
     rpc capability_get(CapabilityGetRequest) returns (Capability) {}
@@ -55,7 +55,7 @@ service RunmResource {
     // Returns information about a specific consumer type
     rpc consumer_type_get(ConsumerTypeGetRequest) returns (ConsumerType) {}
 
-    // Deletes one or more consumer typees
+    // Deletes one or more consumer types
     rpc consumer_type_delete(ConsumerTypeDeleteRequest) returns (
         ConsumerTypeDeleteResponse) {}
 
@@ -70,7 +70,7 @@ service RunmResource {
     // Returns information about a specific consumer type
     rpc consumer_get(ConsumerGetRequest) returns (Consumer) {}
 
-    // Deletes one or more consumer typees
+    // Deletes one or more consumer types
     rpc consumer_delete(ConsumerDeleteRequest) returns (
         ConsumerDeleteResponse) {}
 
@@ -83,7 +83,7 @@ service RunmResource {
     // Returns information about a specific distance type
     rpc distance_type_get(DistanceTypeGetRequest) returns (DistanceType) {}
 
-    // Deletes one or more distance typees
+    // Deletes one or more distance types
     rpc distance_type_delete(DistanceTypeDeleteRequest) returns (
         DistanceTypeDeleteResponse) {}
 
@@ -111,7 +111,7 @@ service RunmResource {
     // Returns information about a specific provider type
     rpc provider_type_get(ProviderTypeGetRequest) returns (ProviderType) {}
 
-    // Deletes one or more provider typees
+    // Deletes one or more provider types
     rpc provider_type_delete(ProviderTypeDeleteRequest) returns (
         ProviderTypeDeleteResponse) {}
 
@@ -201,43 +201,43 @@ service RunmResource {
 }
 
 // RPC Request payload messages
-message ResourceClassGetRequest {
+message ResourceTypeGetRequest {
     Session session = 1;
     string search = 2;
 }
 
-message ResourceClassSetFields {
+message ResourceTypeSetFields {
     StringValue code = 1;
     StringValue description = 2;
 }
 
-message ResourceClassSetRequest {
+message ResourceTypeSetRequest {
     Session session = 1;
-    ResourceClass resource_class = 2;
-    ResourceClassSetFields changed = 3;
+    ResourceType resource_type = 2;
+    ResourceTypeSetFields changed = 3;
 }
 
-message ResourceClassSetResponse {
+message ResourceTypeSetResponse {
     repeated Error errors = 1;
-    ResourceClass resource_class = 2;
+    ResourceType resource_type = 2;
 }
 
-message ResourceClassListFilters {
+message ResourceTypeListFilters {
     repeated string identifiers = 1;
 }
 
-message ResourceClassListRequest {
+message ResourceTypeListRequest {
     Session session = 1;
-    ResourceClassListFilters filters = 2;
+    ResourceTypeListFilters filters = 2;
     SearchOptions options = 3;
 }
 
-message ResourceClassDeleteRequest {
+message ResourceTypeDeleteRequest {
     Session session = 1;
-    repeated ResourceClass resource_classes = 2;
+    repeated ResourceType resource_types = 2;
 }
 
-message ResourceClassDeleteResponse {
+message ResourceTypeDeleteResponse {
     repeated Error errors = 1;
     uint64 num_deleted = 2;
 }
@@ -616,7 +616,7 @@ message ProviderInventoriesSetResponse {
 }
 
 message ProviderInventoriesListFilters {
-    repeated string resource_class_identifiers = 1;
+    repeated string resource_type_identifiers = 1;
 }
 
 message ProviderInventoriesListRequest {
@@ -627,7 +627,7 @@ message ProviderInventoriesListRequest {
 }
 
 message ProviderAllocationsListFilters {
-    repeated string resource_class_identifiers = 1;
+    repeated string resource_type_identifiers = 1;
     int64 claim_time = 2;
     int64 release_time = 3;
 }

--- a/proto/defs/usage.proto
+++ b/proto/defs/usage.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 
 package runm;
 
-import "resource_class.proto";
+import "resource_type.proto";
 
-// Represents the sum of a particular class of resources that has been consumed
+// Represents the sum of a particular type of resources that has been consumed
 message Usage {
-    ResourceClass resource_class = 1;
+    ResourceType resource_type = 1;
     uint64 used = 2;
 }


### PR DESCRIPTION
Adds documentation for the runm-metadata service and what that's all about, and the importance of having a structured object metadata and tagging functionality.

Also renames resource class -> resource type to make it consistent with the other type-classes in the system.