### PR TITLE
Slightly change Allocation field names

### DIFF
--- a/proto/defs/allocation.proto
+++ b/proto/defs/allocation.proto
@@ -16,7 +16,7 @@ message AllocationItem {
 
 message Allocation {
     Consumer consumer = 1;
-    int64 claim_time = 2;
+    int64 acquire_time = 2;
     int64 release_time = 3;
     repeated AllocationItem items = 50;
 }

--- a/proto/defs/service_resource.proto
+++ b/proto/defs/service_resource.proto
@@ -628,8 +628,8 @@ message ProviderInventoriesListRequest {
 
 message ProviderAllocationsListFilters {
     repeated string resource_type_identifiers = 1;
-    int64 claim_time = 2;
-    int64 release_time = 3;
+    int64 start_time = 2;
+    int64 end_time = 3;
 }
 
 message ProviderAllocationsListRequest {
@@ -777,8 +777,8 @@ message ClaimExecuteResponse {
 message UsageListFilters {
     repeated string user_identifiers = 1;
     repeated string project_identifiers = 2;
-    int64 claim_time = 3;
-    int64 release_time = 4;
+    int64 start_time = 3;
+    int64 end_time = 4;
 }
 
 message UsageListRequest {


### PR DESCRIPTION
Changes Allocation.claim_time to Allocation.acquire_time. Keeps
Allocation.release_time the same.

For the UsageListFilters and ProviderAllocationListFilters objects used
in the service API, changes claim_time to start_time and release_time to
end_time, since that makes more sense from the end-user perspective
(give me usage between start and end times)