### PR TITLE
runm-metadata documentation

### DIFF
--- a/cmd/runm-metadata/README.md
+++ b/cmd/runm-metadata/README.md
@@ -1,4 +1,4 @@
-# runm-metadata
+# The `runm-metadata` service
 
 Most software needs to provide users (and the system itself) with the ability
 to associate information with objects the system knows about. This information

--- a/cmd/runm-metadata/README.md
+++ b/cmd/runm-metadata/README.md
@@ -45,18 +45,95 @@ and the free-for-all world of ungoverned labeling of objects.
 
 The `runm-metadata` service tries to achieve this balance.
 
-## Functionality provided by `runm-metadata`
+## Concepts
 
-TODO
+The `runm-metadata` service provides a structured lookup service for object
+metadata in the `runmachine` system. The term "metadata" unfortunately has been
+a bit overloaded by software designers and doesn't really have a common
+definition. So, let's start with some definitions that will be handy when
+discussing the concepts of metadata.
+
+First, a `runmachine` system acts on many ***objects***.  An object can be
+considered a simple record of some *thing* that `runmachine` knows about.
+
+All objects have a specific **type**. Examples of object types in `runmachine`
+are `runm.machine` or `runm.project`.
+
+All objects are identified by an **external identifier** that is **globally
+unique**. We use UUID values for these external identifiers.
+
+All objects have an **name** that is unique **within a particular scope**.
+Typically this scope is the combination of a **partition** and a **project**.
+
+In addition to their type, external identifier and name, all objects may have
+**metadata** associated with them. There are two kinds of metadata that may be
+associated with an object:
+
+* A **tag** is a simple string
+* A **property** is a key/value pair
+
+Tags are simple. The have no restrictions on structure or format, and they may
+be added or removed from an object by any user belonging to the project that
+owns the object (or any user having `SUPER` privileges).
+
+Properties, on the other hand, may have a **schema** associated with the
+**key**. This schema can define the data type and format of the **value**
+component, can restrict read and/or write access to property, and associates a
+**version** with the property's schema so that the definition of that property
+can evolve over time in a measured fashion.
 
 ### Name to UUID lookups
 
-TODO
+An extremely common operation that a user (or the system itself) must perform
+is correlating a human-readable name with some identifier (such as a UUID).
+Likewise, the reverse operation, of correlating a UUID with a human-readable
+name, is extremely common.
+
+`runm-metadata` provides this name to UUID and UUID to name translation
+functionality as a service to other `runmachine` service components. This
+enables all other `runmachine` components to exclusively store UUID identifiers
+in their backend data stores, enabling more efficient storage and retrieval of
+information for those components.
 
 ### Property schemas
 
-TODO
+Users with certain privileges may define **property schemas** for a specific
+property **key**. This schema is a document that describes the data type
+restrictions and format for the **value** component of the property.
 
-### Object tagging
+For example, let's say that an administrator wanted objects of type
+`runm.image` to require an "os" property be associated with it. Furthermore,
+this "os" property would be restricted to one of the following string values:
 
-TODO
+* "linux/redhat"
+* "linux/debian"
+* "windows"
+
+The administrator might create a property schema that looked like this:
+
+```yaml
+key: os
+object_type: runm.image
+schema:
+  type: string
+  enum:
+    - linux/redhat
+    - linux/debian
+    - windows
+  required: true
+```
+
+The `runmachine` system will now be able to use that property schema to guard
+the possible values that are allowed in the "os" properties on `runm.image`
+objects. In addition, property schema definitions which provide valuable
+information for UIs and external systems that need to discover how and what
+kind of data may be associated with different categories of objects that
+`runmachine` knows about.
+
+### Simple tagging
+
+Object tags are super simple strings associated with any object. There are no
+restrictions on who can read or write these strings nor are there restrictions
+on what the strings look like. This makes simple tags convenient for quick and
+dirty labeling of objects, but they can be prone to duplication, misspelling
+and abuse by a group's tribal knowledge.

--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -1,0 +1,95 @@
+# Internal data layout for `runm-metadata`
+
+The `runm-metadata` service uses an [etcd3](https://coreos.com/etcd/) key-value
+store (KVS) for its backend data storage needs.
+
+This document outlines how the keys are organized in `etcd` and how "indexes"
+are built into the key layout so as to efficiently locate groups of keys by
+prefix.
+
+## Key layout
+
+The root of the tree of keys in `etcd` used by the `runm-metadata` service
+always starts at the value designated by the
+`RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX` environs variable (or equivalent
+`--storage-etcd-key-prefix` command line option). This value will be referred
+to as the `$ROOT` key namespace (or just `$ROOT` for short) in this document.
+
+All keys directly Under `$ROOT` are partition UUIDs. Because of this, all
+objects that `runm-metadata` owns must always be contained within a single
+partition, and objects are always identified using a partition identifier.
+
+```
+$ROOT
+  /d3873f99a21f45f5bce156c1f8b84b03
+  /d79706e01fbd4e48aae89209061cdb71
+```
+
+Above, the `etcd` keys under `$ROOT` all represent partitions. So,
+`d3873f99a21f45f5bce156c1f8b84b03` and `d79706e01fbd4e48aae89209061cdb71` are
+the two partitions that this deployment of `runmachine` knows about.
+
+**NOTE**: Typically, clients interacting with `runm-metadata` automatically
+inject a partition identifier into the session when communicating with a
+`runmachine` component, so this partition identifier isn't usually something
+that one specifies manually on the command line.
+
+We will refer to an individual partition key namespace as `$PARTITION` from
+here on.
+
+Under `$PARTITION`, we store information about the objects and property schemas
+in the partition:
+
+```
+$PARTITION (e.g. $ROOT/d79706e01fbd4e48aae89209061cdb71)
+  /objects
+  /property_schemas
+```
+
+We will refer to the `$PARTITION/objects` key namespace as `$OBJECT` from here
+on. Similarly, we will refer to `$PARTITION/property_schemas` as just
+`$PROPERTY_SCHEMAS`
+
+## The `$OBJECTS` key namespace
+
+Let's first take a look at what is contained in the `$OBJECTS` key
+namespace. This key namespace contains three additional key namespaces, the
+names of which indicate what the keys in that key namespace contain.
+
+```
+$OBJECTS
+  /by-type
+  /uuids
+```
+
+The `$OBJECTS/by-type` key namespace contains additional key namespaces,
+arranged in an a series of indexes so that `runm-metadata` can look up UUIDs of
+various objects of that type that belong to a project and have a particular
+name.
+
+Here's an example key layout for a partition that has two image objects named
+`rhel7.5.2` and `debian-sid` in a project with the UUID
+`eff883565999408dbec3eb5070d5ecf5`:
+
+```
+$OBJECTS
+  /by-type
+    /runm.image
+      /by-project
+        /eff883565999408dbec3eb5070d5ecf5
+          /by-name
+            /rhel7.5.2
+              /54b8d8d7e24c43799bbf70c16e921e52
+            /debian-sid
+              /60b53edd16764f6abc081ddb0a73e69c
+          /uuids
+            /60b53edd16764f6abc081ddb0a73e69c
+            /54b8d8d7e24c43799bbf70c16e921e52
+      /uuids
+        /54b8d8d7e24c43799bbf70c16e921e52
+        /60b53edd16764f6abc081ddb0a73e69c
+    ...
+```
+
+The `$OBJECTS/uuids` key namespace contains keys with UUID identifiers of all
+objects in the partition, regardless of type.

--- a/cmd/runm/commands/root.go
+++ b/cmd/runm/commands/root.go
@@ -64,7 +64,7 @@ func addConnectFlags() {
 			"RUNM_HOST",
 			defaultConnectHost,
 		),
-		"The host where the Procession API can be found.",
+		"The host where the runmachine API can be found.",
 	)
 	RootCommand.PersistentFlags().IntVarP(
 		&connectPort,
@@ -73,7 +73,7 @@ func addConnectFlags() {
 			"RUNM_PORT",
 			defaultConnectPort,
 		),
-		"The port where the Procession API can be found.",
+		"The port where the runmachine API can be found.",
 	)
 	RootCommand.PersistentFlags().StringVarP(
 		&authUser,
@@ -82,7 +82,7 @@ func addConnectFlags() {
 			"RUNM_USER",
 			"",
 		),
-		"UUID, email or \"slug\" of the user to log in to Procession with.",
+		"UUID, email or \"slug\" of the user to execute commands with.",
 	)
 }
 

--- a/scripts/exec-runm-command.sh
+++ b/scripts/exec-runm-command.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 DEBUG=${DEBUG:-0}
+VERBOSE=${VERBOSE:-0}
 VERSION=$(git describe --tags --always --dirty)
 ROOT_DIR=$(cd $(dirname "$0")/.. && pwd)
 SCRIPTS_DIR=$ROOT_DIR/scripts
@@ -22,7 +23,7 @@ if [ $? -ne 0 ]; then
     make build
 fi
 
-EXEC_COMMAND=$1
+EXEC_COMMAND="$@"
 ETCD_CONTAINER_NAME=${ETCD_CONTAINER_NAME:-"runm-test-etcd"}
 METADATA_CONTAINER_NAME=${METADATA_CONTAINER_NAME:-"runm-test-metadata"}
 
@@ -31,12 +32,12 @@ if ! container_is_running "$ETCD_CONTAINER_NAME"; then
 fi
 
 if ! container_get_ip "$ETCD_CONTAINER_NAME" etcd_container_ip; then
-    echo "ERROR: failed to get etcd container IP"
+    echo "ERROR: could not get IP for etcd container"
     exit 1
 fi
 
 if ! container_is_running "$METADATA_CONTAINER_NAME"; then
-    echo -n "Starting runm-metadata container named $METADATA_CONTAINER_NAME... "
+    inline_if_verbose "Starting runm-metadata container named $METADATA_CONTAINER_NAME... "
     docker run -d \
         --rm \
         -p 10000:10000 \
@@ -46,17 +47,23 @@ if ! container_is_running "$METADATA_CONTAINER_NAME"; then
         -e RUNM_LOG_LEVEL=3 \
         -e RUNM_METADATA_STORAGE_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
         -e RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX="$METADATA_CONTAINER_NAME" \
-        runm-metadata:$VERSION # >/dev/null 2>&1
-    echo "ok."
+        runm-metadata:$VERSION >/dev/null 2>&1
+    print_if_verbose "ok."
 fi
 
-echo -n "Grabbing IP for $METADATA_CONTAINER_NAME ... "
+inline_if_verbose "Grabbing IP for $METADATA_CONTAINER_NAME ... "
 if container_get_ip "$METADATA_CONTAINER_NAME" metadata_container_ip; then
-    echo "ok."
+    print_if_verbose "ok."
     print_if_verbose "runm-metadata running in container at ${metadata_container_ip}:10000."
 else
-    echo "FAIL"
+    echo "ERROR: could not get IP for runm-metadata container"
     exit 1
 fi
+
+print_if_verbose ""
+print_if_verbose "*********************************************************************"
+print_if_verbose "Running \`runm $EXEC_COMMAND\` in single-use docker container..."
+print_if_verbose "*********************************************************************"
+print_if_verbose ""
 
 docker run --rm --network host runm:$VERSION runm $EXEC_COMMAND


### PR DESCRIPTION
* Completes the TODOs in the main README for the metadata service
* Begins documentation of the etcd key namespace layout for indexed access to object metadata