### PR TITLE
metadata: ensure root key namespace + docs

### DIFF
--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -146,7 +146,6 @@ $OBJECTS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/objects
   /by-uuid
     /54b8d8d7e24c43799bbf70c16e921e52
     /60b53edd16764f6abc081ddb0a73e69c
-    ...
 ```
 
 As you see above, the `$OBJECTS/by-type` key namespace contains additional key
@@ -160,7 +159,31 @@ The example key layout above shows a partition that has two image objects named
 
 ### The `$PROPERTY_SCHEMAS` key namespace
 
-TODO
+The `$PROPERTY_SCHEMAS` key namespace stores information about the property
+schemas defined within a partition. The key namespace itself has a very simple
+layout:
+
+```
+$PROPERTY_SCHEMAS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/property-schemas)
+  /by-type
+    /runm.image
+      /architecture
+        /1 -> serialized PropertySchema protobuffer message
+        /2 -> serialized PropertySchema protobuffer message
+    /runm.machine
+      /appgroup
+        /1 -> serialized PropertySchema protobuffer message
+```
+
+Above shows an example key namespace for `$PROPERTY_SCHEMAS` in a partition
+where an administrator has defined two property schemas, one for `runm.image`
+object types with a property key of "architecture" and another for
+`runm.machine` object types with a property key of "appgroup". Under the key
+namespace representing the property schemas for an object type (e.g.
+`$PROPERTY_SCHEMAS/by-type/runm.image`) are additional key namespaces, one for
+each property key that has a schema defined for it. The valued keys in those
+key namespaces have keys representing the schema *version* and the value is a
+serialized Protobuffer message representing the [property schema](../../../proto/defs/property_schema.proto) itself.
 
 ### The `$PROPERTIES` key namespace
 

--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -143,9 +143,15 @@ $OBJECTS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/objects
           /by-name
             /rhel7.5.2 -> 54b8d8d7e24c43799bbf70c16e921e52
             /debian-sid -> 60b53edd16764f6abc081ddb0a73e69c
+    /runm.machine
+      /by-project
+        /eff883565999408dbec3eb5070d5ecf5
+          /by-name
+            /instance0-appgroupA -> 3bf3e700f11b4a7cb99244c554b3a856
   /by-uuid
     /54b8d8d7e24c43799bbf70c16e921e52
     /60b53edd16764f6abc081ddb0a73e69c
+    /3bf3e700f11b4a7cb99244c554b3a856
 ```
 
 As you see above, the `$OBJECTS/by-type` key namespace contains additional key
@@ -155,7 +161,8 @@ particular name.
 
 The example key layout above shows a partition that has two image objects named
 `rhel7.5.2` and `debian-sid` in a project with the UUID
-`eff883565999408dbec3eb5070d5ecf5`.
+`eff883565999408dbec3eb5070d5ecf5`. There is also a machine object named
+`instance0-appgroupA` with the UUID of `3bf3e700f11b4a7cb99244c554b3a856`.
 
 ### The `$PROPERTY_SCHEMAS` key namespace
 
@@ -187,7 +194,33 @@ serialized Protobuffer message representing the [property schema](../../../proto
 
 ### The `$PROPERTIES` key namespace
 
-TODO
+The `$PROPERTIES` key namespace stores information about the object properties
+for all objects known to the partition.
+
+Here is an example layout for a partition with a two `runm.image` objects and
+one `runm.machine` object, with the image objects having an "architecture"
+property associated with them and the machine object having an "appgroup"
+property associated with it:
+
+```
+$PROPERTIES (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/properties)
+  /by-type
+    /runm.image
+      /architecture
+        /x86_64
+          /54b8d8d7e24c43799bbf70c16e921e52
+        /arm64
+          /60b53edd16764f6abc081ddb0a73e69c
+    /runm.machine
+      /appgroup
+        /A
+          /3bf3e700f11b4a7cb99244c554b3a856
+```
+
+`runm-metadata` can use the key namespaces defined in the `$PROPERTIES` key
+namespace to look up objects that have a particular property (key, or key and
+value). The lowest-level keys are UUIDs for the objects that match that
+particular property.
 
 ### The `$TAGS` key namespace
 

--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -149,9 +149,9 @@ $OBJECTS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/objects
           /by-name
             /instance0-appgroupA -> 3bf3e700f11b4a7cb99244c554b3a856
   /by-uuid
-    /54b8d8d7e24c43799bbf70c16e921e52
-    /60b53edd16764f6abc081ddb0a73e69c
-    /3bf3e700f11b4a7cb99244c554b3a856
+    /54b8d8d7e24c43799bbf70c16e921e52 -> serialized Object protobuffer message
+    /60b53edd16764f6abc081ddb0a73e69c -> serialized Object protobuffer message
+    /3bf3e700f11b4a7cb99244c554b3a856 -> serialized Object protobuffer message
 ```
 
 As you see above, the `$OBJECTS/by-type` key namespace contains additional key
@@ -163,6 +163,15 @@ The example key layout above shows a partition that has two image objects named
 `rhel7.5.2` and `debian-sid` in a project with the UUID
 `eff883565999408dbec3eb5070d5ecf5`. There is also a machine object named
 `instance0-appgroupA` with the UUID of `3bf3e700f11b4a7cb99244c554b3a856`.
+
+The valued keys in the `$OBJECTS/by-uuid` key namespace have the UUID of the
+object as the key and a serialized Google Protobuffer message of the
+[Object](../../../proto/defs/object.proto) itself as the value.
+
+**NOTE**: Having the serialized Object protobuffer message as the value of the
+`%OBJECTS/by-uuid` key namespace's valued keys allows the `runm-metadata`
+service to answer queries like "get me the tags on this object" with an
+efficient single key fetch operation.
 
 ### The `$PROPERTY_SCHEMAS` key namespace
 

--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -7,89 +7,165 @@ This document outlines how the keys are organized in `etcd` and how "indexes"
 are built into the key layout so as to efficiently locate groups of keys by
 prefix.
 
-## Key layout
+Before we describe the layout, it's good to go over some terminology.
+
+## Key namespaces
+
+When we use the term **key namespace**, we simply refer to a string key in
+`etcd` that has no value but rather has a set of subkeys "under" it. If you
+think of the `etcd` data store as a filesystem, you can equate a key namespace
+as a directory in the filesystem.
+
+So, a key of `/a/b` is a key namspace if there exists additional keys (or key
+namespaces) *under* `/a/b`, such as `/a/b/c` or `/a/b/d/e`.
+
+When showing a key namespace, we use a directory-like structure, like so:
+
+```
+/a
+  /b
+    /c
+    /d
+      /e
+```
+
+## Valued keys
+
+If you see a `{key} -> {value}` in the directory layout, that means that there
+is a non-nil value for the key.
+
+For instance, in the following graphic, the key `e` has a value stored of `x`:
+
+```
+/a
+  /b
+    /c
+    /d
+      /e -> x
+```
+
+We refer to these types of keys that have a non-nil as **valued keys**. Valued
+keys are often used by `runm-metadata` as a way to build **indexes** into the
+underlying data, allowing fast lookup of information by non-UUID values.
+
+## Understanding the key layout
 
 The root of the tree of keys in `etcd` used by the `runm-metadata` service
 always starts at the value designated by the
 `RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX` environs variable (or equivalent
-`--storage-etcd-key-prefix` command line option). This value will be referred
-to as the `$ROOT` key namespace (or just `$ROOT` for short) in this document.
+`--storage-etcd-key-prefix` command line option) and is followed by the
+constant `runm-metadata`.
 
-All keys directly Under `$ROOT` are partition UUIDs. Because of this, all
-objects that `runm-metadata` owns must always be contained within a single
-partition, and objects are always identified using a partition identifier.
+So, for example, assuming that `RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX` is its
+default value of `/`. The top-level key namespace in `etcd` for all
+`runm-metadata` data would be the string `/runm-metadata`:
+
+```
+/runm-metadata
+```
+
+This value will be referred to as the `$ROOT` key namespace (or just `$ROOT`
+for short) in this document.
+
+### The `$ROOT` key namespace
+
+The keys directly Under `$ROOT` describe the known **partitions** in the
+system. It's easier to explain the structure by looking at a sample key
+namespace layout.
 
 ```
 $ROOT
-  /d3873f99a21f45f5bce156c1f8b84b03
-  /d79706e01fbd4e48aae89209061cdb71
+  /partitions
+    /by-name
+      /us-east.example.com -> d3873f99a21f45f5bce156c1f8b84b03
+      /us-west.example.com -> d79706e01fbd4e48aae89209061cdb71
+    /by-uuid
+      /d3873f99a21f45f5bce156c1f8b84b03
+      /d79706e01fbd4e48aae89209061cdb71
 ```
 
-Above, the `etcd` keys under `$ROOT` all represent partitions. So,
-`d3873f99a21f45f5bce156c1f8b84b03` and `d79706e01fbd4e48aae89209061cdb71` are
-the two partitions that this deployment of `runmachine` knows about.
+Above, you can see that `$ROOT` has a single key namespace called `partitions`.
+This key has two key namespaces below it, called `by-name` and `by-uuid`.
+
+The `$ROOT/partitions/by-name` key namespace contains [valued keys](#Valued
+keys), with the key being the human-readable name of the partition and the
+value being the UUID of that partition.
+
+Each UUID value listed in `$ROOT/partitions/by-name` will be a key namespace
+under `$ROOT/partitions/by-uuid` that contains *all* objects known to that
+partition. We call these key namespaces "partition key namespaces".
 
 **NOTE**: Typically, clients interacting with `runm-metadata` automatically
 inject a partition identifier into the session when communicating with a
 `runmachine` component, so this partition identifier isn't usually something
-that one specifies manually on the command line.
+that one specifies manually on the command line. Instead, a configuration file
+or environment variable contains the human-readable name of the partition that
+the user is communicating with.
 
-We will refer to an individual partition key namespace as `$PARTITION` from
+Therefore, the partition key namespace for the partition with UUID
+`d79706e01fbd4e48aae89209061cdb71` will always be
+`$ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71`.
+
+We will refer to an **individual partition key namespace** as `$PARTITION` from
 here on.
 
-Under `$PARTITION`, we store information about the objects and property schemas
-in the partition:
+### The `$PARTITION` key namespace
+
+Under `$PARTITION`, we store information about the objects, property schemas,
+and the object metadata (properties and tags) in the partition:
 
 ```
-$PARTITION (e.g. $ROOT/d79706e01fbd4e48aae89209061cdb71)
+$PARTITION (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71)
   /objects
-  /property_schemas
+  /property-schemas
+  /properties
+  /tags
 ```
 
 We will refer to the `$PARTITION/objects` key namespace as `$OBJECT` from here
-on. Similarly, we will refer to `$PARTITION/property_schemas` as just
-`$PROPERTY_SCHEMAS`
+on. Similarly, we will refer to `$PARTITION/property-schemas` as just
+`$PROPERTY_SCHEMAS`, `$PARTITION/properties` as just `$PROPERTIES` and
+`$PARTITION/tags` as just `$TAGS`. Each of these key namespaces is described in
+detail in the following sections.
 
-## The `$OBJECTS` key namespace
+### The `$OBJECTS` key namespace
 
 Let's first take a look at what is contained in the `$OBJECTS` key
-namespace. This key namespace contains three additional key namespaces, the
-names of which indicate what the keys in that key namespace contain.
+namespace. Similar to the `$ROOT/partitions` key namespace, the `$OBJECTS` key
+namespace contains two key namespaces called `by-type` and `by-uuid`:
 
 ```
-$OBJECTS
-  /by-type
-  /uuids
-```
-
-The `$OBJECTS/by-type` key namespace contains additional key namespaces,
-arranged in an a series of indexes so that `runm-metadata` can look up UUIDs of
-various objects of that type that belong to a project and have a particular
-name.
-
-Here's an example key layout for a partition that has two image objects named
-`rhel7.5.2` and `debian-sid` in a project with the UUID
-`eff883565999408dbec3eb5070d5ecf5`:
-
-```
-$OBJECTS
+$OBJECTS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/objects)
   /by-type
     /runm.image
       /by-project
         /eff883565999408dbec3eb5070d5ecf5
           /by-name
-            /rhel7.5.2
-              /54b8d8d7e24c43799bbf70c16e921e52
-            /debian-sid
-              /60b53edd16764f6abc081ddb0a73e69c
-          /uuids
-            /60b53edd16764f6abc081ddb0a73e69c
-            /54b8d8d7e24c43799bbf70c16e921e52
-      /uuids
-        /54b8d8d7e24c43799bbf70c16e921e52
-        /60b53edd16764f6abc081ddb0a73e69c
+            /rhel7.5.2 -> 54b8d8d7e24c43799bbf70c16e921e52
+            /debian-sid -> 60b53edd16764f6abc081ddb0a73e69c
+  /by-uuid
+    /54b8d8d7e24c43799bbf70c16e921e52
+    /60b53edd16764f6abc081ddb0a73e69c
     ...
 ```
 
-The `$OBJECTS/uuids` key namespace contains keys with UUID identifiers of all
-objects in the partition, regardless of type.
+As you see above, the `$OBJECTS/by-type` key namespace contains additional key
+namespaces, arranged in an a series of indexes so that `runm-metadata` can look
+up UUIDs of various objects of that type that belong to a project and have a
+particular name.
+
+The example key layout above shows a partition that has two image objects named
+`rhel7.5.2` and `debian-sid` in a project with the UUID
+`eff883565999408dbec3eb5070d5ecf5`.
+
+### The `$PROPERTY_SCHEMAS` key namespace
+
+TODO
+
+### The `$PROPERTIES` key namespace
+
+TODO
+
+### The `$TAGS` key namespace
+
+TODO

--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -224,4 +224,19 @@ particular property.
 
 ### The `$TAGS` key namespace
 
-TODO
+Finally, the `$TAGS` namespace contains all the simple string tags for objects
+in a partition. The structure of this key namespace looks like this:
+
+```
+$TAGS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/tags)
+  /unicorn
+    /54b8d8d7e24c43799bbf70c16e921e52
+    /60b53edd16764f6abc081ddb0a73e69c
+  /rainbow
+    /3bf3e700f11b4a7cb99244c554b3a856
+```
+
+Above, we have three objects in the partition that have tags decorating them.
+Two objects are decorated with a tag "unicorn" and one object is decorated with
+a tag "rainbow". The lowest-level keys within each tag key namespace are the
+object's UUID.

--- a/pkg/metadata/storage/bootstrap.go
+++ b/pkg/metadata/storage/bootstrap.go
@@ -1,0 +1,65 @@
+package storage
+
+import (
+	"context"
+
+	etcd "github.com/coreos/etcd/clientv3"
+)
+
+// bootstrap is responsible for creating the etcd key namespace layout that the
+// `runm-metadata` service uses to store and fetch information about the
+// objects in the system.
+func (s *Store) bootstrap(ctx context.Context) error {
+	// ensure that we have the $ROOT key namespace created
+	rootNs := "/"
+	rootExists, err := s.keyNamespaceExists(ctx, s.kv, rootNs)
+	if err != nil {
+		return err
+	} else if !rootExists {
+		s.log.L3("bootstrapping: root namespace does not exist. creating...")
+		if err = s.keyNamespaceCreate(ctx, s.kv, rootNs); err != nil {
+			return err
+		}
+		s.log.L3("bootstrapping: root namespace created")
+	} else {
+		s.log.L3("bootstrapping: root namespace already exists")
+	}
+	s.bootstrapped = true
+	return nil
+}
+
+func (s *Store) keyNamespaceExists(
+	ctx context.Context,
+	kv etcd.KV,
+	ns string,
+) (bool, error) {
+	gr, err := kv.Get(ctx, ns, etcd.WithPrefix())
+	if err != nil {
+		s.log.ERR("error getting key namespace %s: %v", ns, err)
+		return false, err
+	}
+	return (len(gr.Kvs) > 0), nil
+}
+
+// createKeyNamespace creates the supplied key namespace. If the namespace
+// already exists, or another thread creates it during execution, returns nil
+func (s *Store) keyNamespaceCreate(
+	ctx context.Context,
+	kv etcd.KV,
+	ns string,
+) error {
+	// create the key namespace using a transaction that ensures if another
+	// thread creates it underneath us, that we just ignore and return nil
+	onSuccess := etcd.OpPut(ns, _NO_VALUE)
+	// Ensure the key doesn't yet exist
+	compare := etcd.Compare(etcd.Version(ns), "=", 0)
+	resp, err := kv.Txn(ctx).If(compare).Then(onSuccess).Commit()
+
+	if err != nil {
+		s.log.ERR("failed to create txn in etcd: %v", err)
+		return err
+	} else if resp.Succeeded == false {
+		s.log.L3("another thread already created namespace %s. ignoring...", ns)
+	}
+	return nil
+}

--- a/pkg/metadata/storage/property.go
+++ b/pkg/metadata/storage/property.go
@@ -24,7 +24,7 @@ func (s *Store) PropertySchemaList(
 	ctx, cancel := s.requestCtx()
 	resp, err := kv.Get(
 		ctx,
-		"",
+		"/",
 		etcd.WithPrefix(),
 		// TODO(jaypipes): Factor the sorting/limiting/pagination out into a
 		// separate utility


### PR DESCRIPTION
Adds lots of documentation about the etcd key layout for the `runm-metadata` service and adds code to the metadata package's New() function to bootstrap the etcd layout with a root key namespace.