### PR TITLE
metadata: property-schema get

### DIFF
--- a/cmd/runm/commands/common.go
+++ b/cmd/runm/commands/common.go
@@ -7,6 +7,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	pb "github.com/runmachine-io/runmachine/proto"
 )
 
 const (
@@ -83,8 +85,29 @@ func exitNoRecords() {
 	os.Exit(0)
 }
 
+// getSession constructs a Session protobuffer message by looking for
+// partition, user and project information in a variety of configuration file,
+// CLI argument and environs variable locations.
+func getSession() *pb.Session {
+	user := authUser
+	project := authProject
+	partition := authPartition
+	if user == "" || project == "" || partition == "" {
+		// TODO(jaypipes): Load a YAML configuration file where we might be
+		// able to find missing user/project/partition information
+	}
+	return &pb.Session{
+		User:    user,
+		Project: project,
+		Partition: &pb.Partition{
+			Uuid: partition,
+		},
+	}
+}
+
 func connect() *grpc.ClientConn {
 	var opts []grpc.DialOption
+	// TODO(jaypipes): Don't hardcode this to WithInsecure
 	opts = append(opts, grpc.WithInsecure())
 	addr := fmt.Sprintf("%s:%d", connectHost, connectPort)
 	printIf(verbose, "connecting to runm services at %s\n", addr)

--- a/cmd/runm/commands/property_schema.go
+++ b/cmd/runm/commands/property_schema.go
@@ -11,4 +11,5 @@ var propertySchemaCommand = &cobra.Command{
 
 func init() {
 	propertySchemaCommand.AddCommand(propertySchemaListCommand)
+	propertySchemaCommand.AddCommand(propertySchemaGetCommand)
 }

--- a/cmd/runm/commands/property_schema_get.go
+++ b/cmd/runm/commands/property_schema_get.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	pb "github.com/runmachine-io/runmachine/proto"
+	"github.com/spf13/cobra"
+)
+
+var propertySchemaGetCommand = &cobra.Command{
+	Use:   "get <object_type> <key>",
+	Short: "Show information for a single property schema",
+	Args:  cobra.ExactArgs(2),
+	Run:   propertySchemaGet,
+}
+
+func propertySchemaGet(cmd *cobra.Command, args []string) {
+	conn := connect()
+	defer conn.Close()
+
+	client := pb.NewRunmMetadataClient(conn)
+	req := &pb.PropertySchemaGetRequest{
+		Session: getSession(),
+		ObjectType: &pb.ObjectType{
+			Code: args[0],
+		},
+		Key: args[1],
+	}
+	obj, err := client.PropertySchemaGet(context.Background(), req)
+	exitIfError(err)
+	fmt.Printf("Partition:    %s\n", obj.Partition.Uuid)
+	fmt.Printf("Object type:  %s\n", obj.ObjectType.Code)
+	fmt.Printf("Key:          %s\n", obj.Key)
+	fmt.Printf("Version:      %d\n", obj.Version)
+	fmt.Printf("Schema:\n%s\n", obj.Schema)
+}

--- a/cmd/runm/commands/property_schema_list.go
+++ b/cmd/runm/commands/property_schema_list.go
@@ -26,7 +26,7 @@ func propertySchemaList(cmd *cobra.Command, args []string) {
 
 	client := pb.NewRunmMetadataClient(conn)
 	req := &pb.PropertySchemaListRequest{
-		Session: &pb.Session{},
+		Session: getSession(),
 		Filters: filters,
 	}
 	stream, err := client.PropertySchemaList(context.Background(), req)

--- a/cmd/runm/commands/root.go
+++ b/cmd/runm/commands/root.go
@@ -30,12 +30,14 @@ const (
 )
 
 var (
-	quiet       bool
-	verbose     bool
-	connectHost string
-	connectPort int
-	authUser    string
-	clientLog   Logger
+	quiet         bool
+	verbose       bool
+	connectHost   string
+	connectPort   int
+	authPartition string
+	authUser      string
+	authProject   string
+	clientLog     Logger
 )
 
 var RootCommand = &cobra.Command{
@@ -76,6 +78,15 @@ func addConnectFlags() {
 		"The port where the runmachine API can be found.",
 	)
 	RootCommand.PersistentFlags().StringVarP(
+		&authPartition,
+		"partition", "",
+		envutil.WithDefault(
+			"RUNM_PARTITION",
+			"",
+		),
+		"UUID or name of the partition to execute commands against.",
+	)
+	RootCommand.PersistentFlags().StringVarP(
 		&authUser,
 		"user", "",
 		envutil.WithDefault(
@@ -83,6 +94,15 @@ func addConnectFlags() {
 			"",
 		),
 		"UUID, email or \"slug\" of the user to execute commands with.",
+	)
+	RootCommand.PersistentFlags().StringVarP(
+		&authProject,
+		"project", "",
+		envutil.WithDefault(
+			"RUNM_PROJECT",
+			"",
+		),
+		"UUID or name of the project to execute commands under.",
 	)
 }
 

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -1,0 +1,38 @@
+package errors
+
+import (
+	"fmt"
+)
+
+type Error struct {
+	HTTPCode int
+	Code     int
+	Message  string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("ERROR(%d): %s", e.Code, e.Message)
+}
+
+var (
+	ErrNotFound = &Error{
+		HTTPCode: 404,
+		Code:     404,
+		Message:  "object could not be found.",
+	}
+	ErrDuplicate = &Error{
+		HTTPCode: 409,
+		Code:     409001,
+		Message:  "object already exists.",
+	}
+	ErrMultipleRecords = &Error{
+		HTTPCode: 409,
+		Code:     409002,
+		Message:  "found multiple records when expected to find one.",
+	}
+	ErrGenerationConflict = &Error{
+		HTTPCode: 409,
+		Code:     409003,
+		Message:  "encountered generation conflict.",
+	}
+)

--- a/pkg/metadata/property.go
+++ b/pkg/metadata/property.go
@@ -3,7 +3,31 @@ package metadata
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	pb "github.com/runmachine-io/runmachine/proto"
+
+	"github.com/runmachine-io/runmachine/pkg/errors"
+)
+
+var (
+	ErrUnknown = status.Errorf(
+		codes.Unknown,
+		"an unknown error occurred.",
+	)
+	ErrNotFound = status.Errorf(
+		codes.NotFound,
+		"object could not be found.",
+	)
+	ErrPartitionRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"partition is required.",
+	)
+	ErrObjectTypeRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"object type is required.",
+	)
 )
 
 func (s *Server) PropertySchemaDelete(
@@ -13,11 +37,43 @@ func (s *Server) PropertySchemaDelete(
 	return nil, nil
 }
 
+// PropertySchemaGet looks up a property schema by partition, object type and
+// property key and returns a PropertySchema protobuf message.
 func (s *Server) PropertySchemaGet(
 	ctx context.Context,
 	req *pb.PropertySchemaGetRequest,
 ) (*pb.PropertySchema, error) {
-	return nil, nil
+	if req.ObjectType == nil {
+		return nil, ErrObjectTypeRequired
+	}
+	version := uint32(1)
+	if req.Version != nil {
+		version = req.Version.Value
+	}
+	var partition string
+	if req.Partition != nil {
+		// TODO(jaypipes): AUTHZ check user can specify partition
+		partition = req.Partition.Uuid
+	} else {
+		if req.Session.Partition == nil {
+			return nil, ErrPartitionRequired
+		}
+		partition = req.Session.Partition.Uuid
+	}
+	// TODO(jaypipes): Validate the supplied object type even exists
+	obj, err := s.store.PropertySchemaGet(
+		partition,
+		req.ObjectType.Code,
+		req.Key,
+		version,
+	)
+	if err != nil {
+		if err == errors.ErrNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, ErrUnknown
+	}
+	return obj, nil
 }
 
 func (s *Server) PropertySchemaList(

--- a/pkg/metadata/storage/property.go
+++ b/pkg/metadata/storage/property.go
@@ -1,27 +1,75 @@
 package storage
 
 import (
+	"fmt"
+
 	etcd "github.com/coreos/etcd/clientv3"
 	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/runmachine-io/runmachine/pkg/abstract"
 	"github.com/runmachine-io/runmachine/pkg/cursor"
+	"github.com/runmachine-io/runmachine/pkg/errors"
 	pb "github.com/runmachine-io/runmachine/proto"
 )
 
 const (
-	_KEY_PROPERTY_SCHEMA = "property_schemas/"
+	_PROPERTY_SCHEMAS_KEY = "property-schemas/"
 )
 
-func (s *Store) kvPropertySchemas() etcd.KV {
-	return etcd_namespace.NewKV(s.kv, _KEY_PROPERTY_SCHEMA)
+func (s *Store) kvPropertySchemas(
+	partition string,
+) etcd.KV {
+	// The $PROPERTY_SCHEMAS key namespace is a shortcut to:
+	// $ROOT/partitions/by-uuid/{partition_uuid}/property-schemas
+	return etcd_namespace.NewKV(
+		s.kvPartition(partition),
+		_PROPERTY_SCHEMAS_KEY,
+	)
+}
+
+func (s *Store) PropertySchemaGet(
+	partition string,
+	objType string,
+	propSchemaKey string,
+	version uint32,
+) (*pb.PropertySchema, error) {
+	kv := s.kvPropertySchemas(partition)
+	ctx, cancel := s.requestCtx()
+	defer cancel()
+	key := fmt.Sprintf("by-type/%s/%s/%d", objType, propSchemaKey, version)
+	gr, err := kv.Get(ctx, key, etcd.WithPrefix())
+	if err != nil {
+		s.log.ERR("error getting key %s: %v", key, err)
+		return nil, err
+	}
+	nKeys := len(gr.Kvs)
+	if nKeys == 0 {
+		return nil, errors.ErrNotFound
+	} else if nKeys > 1 {
+		return nil, errors.ErrMultipleRecords
+	}
+	var obj *pb.PropertySchema
+	if err = proto.Unmarshal(gr.Kvs[0].Value, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
 }
 
 func (s *Store) PropertySchemaList(
 	req *pb.PropertySchemaListRequest,
 ) (abstract.Cursor, error) {
-	kv := s.kvPropertySchemas()
+	partition := req.Session.Partition.Uuid
+	if req.Filters != nil {
+		if len(req.Filters.Partitions) > 0 {
+			// TODO(jaypipes): loop through all searched-for partitions
+			partition = req.Filters.Partitions[0].Uuid
+		}
+	}
+	kv := s.kvPropertySchemas(partition)
 	ctx, cancel := s.requestCtx()
+	defer cancel()
 	resp, err := kv.Get(
 		ctx,
 		"/",
@@ -30,7 +78,6 @@ func (s *Store) PropertySchemaList(
 		// separate utility
 		etcd.WithSort(etcd.SortByKey, etcd.SortAscend),
 	)
-	cancel()
 	if err != nil {
 		s.log.ERR("error listing property schemas: %v", err)
 		return nil, err

--- a/pkg/metadata/storage/store.go
+++ b/pkg/metadata/storage/store.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
 	etcd "github.com/coreos/etcd/clientv3"
 	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
@@ -13,11 +14,15 @@ import (
 const (
 	// The key that carves out a namespace for the runm-metadata service to
 	// store stuff in etcd. This namespace comes directly UNDER the
-	// Config.EtcdKeyPrefix namespace
+	// Config.EtcdKeyPrefix namespace. This namespace is referred to as $ROOT
 	_SERVICE_KEY = "runm-metadata/"
 
 	// Used when creating empty leaf-level keys or key namespaces
 	_NO_VALUE = ""
+
+	// $PARTITION refers to the key namespace at
+	// $ROOT/partitions/by-uuid/{partition_uuid}
+	_PARTITIONS_BY_UUID_KEY = "partitions/by-uuid/%s/"
 )
 
 type Store struct {
@@ -45,6 +50,11 @@ func New(log *logging.Logs, cfg *config.Config) (*Store, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+func (s *Store) kvPartition(partition string) etcd.KV {
+	key := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partition)
+	return etcd_namespace.NewKV(s.kv, key)
 }
 
 func (s *Store) requestCtx() (context.Context, context.CancelFunc) {

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -165,7 +165,11 @@ message ObjectDeleteResponse {
 
 message PropertySchemaGetRequest {
     Session session = 1;
-    string search = 2;
+    // If nil, we use the session's partition
+    Partition partition = 2;
+    ObjectType object_type = 3;
+    string key = 4;
+    UInt32Value version = 5;
 }
 
 message PropertySchemaSetFields {

--- a/proto/defs/session.proto
+++ b/proto/defs/session.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package runm;
 
+import "partition.proto";
+
 // A session is a context for a series of requests made to a service endpoint
 // or executor
 message Session {
@@ -14,5 +16,5 @@ message Session {
     // indicates that the user is accessing information across multiple
     // partitions. This partition identifier, when not empty, will be used when
     // constructing new providers or when listing providers.
-    string partition = 3;
+    Partition partition = 3;
 }


### PR DESCRIPTION
Adds the basics for getting a single property-schema object, specifying
the partition, object type, property key and version of the schema.

Issue #23