### PR TITLE
metadata: property-schema set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ build: test
 .PHONY: clean
 clean:
 	@echo "Cleaning up all built Docker images ..."
-	@docker image prune --force > /dev/null 2>&1
 	@for i in $( docker image list | grep runm | awk '{print $3}' ); do \
-		docker image rm $i --force > /dev/null 2>&1; \
+		docker image rm $i --force; \
 	done
+	@docker image prune --force

--- a/cmd/runm-metadata/Dockerfile
+++ b/cmd/runm-metadata/Dockerfile
@@ -10,5 +10,4 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflag
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /bin/runm-metadata /bin/runm-metadata
-WORKDIR /bin
-CMD ["./runm-metadata"]
+ENTRYPOINT ["/bin/runm-metadata"]

--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -183,12 +183,9 @@ layout:
 $PROPERTY_SCHEMAS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/property-schemas)
   /by-type
     /runm.image
-      /architecture
-        /1 -> serialized PropertySchema protobuffer message
-        /2 -> serialized PropertySchema protobuffer message
+      /architecture -> serialized PropertySchema protobuffer message
     /runm.machine
-      /appgroup
-        /1 -> serialized PropertySchema protobuffer message
+      /appgroup -> serialized PropertySchema protobuffer message
 ```
 
 Above shows an example key namespace for `$PROPERTY_SCHEMAS` in a partition
@@ -198,8 +195,9 @@ object types with a property key of "architecture" and another for
 namespace representing the property schemas for an object type (e.g.
 `$PROPERTY_SCHEMAS/by-type/runm.image`) are additional key namespaces, one for
 each property key that has a schema defined for it. The valued keys in those
-key namespaces have keys representing the schema *version* and the value is a
-serialized Protobuffer message representing the [property schema](../../../proto/defs/property_schema.proto) itself.
+key namespaces have values that are the serialized Protobuffer message
+representing the [property schema](../../../proto/defs/property_schema.proto)
+itself.
 
 ### The `$PROPERTIES` key namespace
 

--- a/cmd/runm/Dockerfile
+++ b/cmd/runm/Dockerfile
@@ -10,5 +10,4 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflag
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /bin/runm /bin/runm
-WORKDIR /bin
-CMD ["./runm"]
+ENTRYPOINT ["/bin/runm"]

--- a/cmd/runm/commands/common.go
+++ b/cmd/runm/commands/common.go
@@ -38,11 +38,7 @@ for the --user CLI option.
 Please check the RUNM_HOST and RUNM_PORT environment
 variables or --host and --port  CLI options.
 `
-	errForbidden     = `Error: you are not authorized to perform that action.`
-	errBadVisibility = `Error: incorrect value for visibility.
-
-Valid values are PUBLIC or PRIVATE.
-`
+	errForbidden = `Error: you are not authorized to perform that action.`
 )
 
 const (

--- a/cmd/runm/commands/property_schema.go
+++ b/cmd/runm/commands/property_schema.go
@@ -10,6 +10,7 @@ var propertySchemaCommand = &cobra.Command{
 }
 
 func init() {
+	propertySchemaCommand.AddCommand(propertySchemaSetCommand)
 	propertySchemaCommand.AddCommand(propertySchemaListCommand)
 	propertySchemaCommand.AddCommand(propertySchemaGetCommand)
 }

--- a/cmd/runm/commands/property_schema_get.go
+++ b/cmd/runm/commands/property_schema_get.go
@@ -9,6 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	// partition override. if empty, we use the session's partition
+	propSchemaGetPartition string
+)
+
 var propertySchemaGetCommand = &cobra.Command{
 	Use:   "get <object_type> <key>",
 	Short: "Show information for a single property schema",
@@ -16,23 +21,41 @@ var propertySchemaGetCommand = &cobra.Command{
 	Run:   propertySchemaGet,
 }
 
+func setupPropertySchemaGetFlags() {
+	propertySchemaGetCommand.Flags().StringVarP(
+		&propSchemaGetPartition,
+		"partition", "p",
+		"",
+		"optional partition in which to look for the property schema.",
+	)
+}
+
+func init() {
+	setupPropertySchemaGetFlags()
+}
+
 func propertySchemaGet(cmd *cobra.Command, args []string) {
 	conn := connect()
 	defer conn.Close()
 
 	client := pb.NewRunmMetadataClient(conn)
+
+	session := getSession()
+	partition := session.Partition.Uuid
+	if propSchemaGetPartition != "" {
+		partition = propSchemaGetPartition
+	}
+
 	req := &pb.PropertySchemaGetRequest{
-		Session: getSession(),
-		ObjectType: &pb.ObjectType{
-			Code: args[0],
-		},
-		Key: args[1],
+		Session:    session,
+		Partition:  partition,
+		ObjectType: args[0],
+		Key:        args[1],
 	}
 	obj, err := client.PropertySchemaGet(context.Background(), req)
 	exitIfError(err)
-	fmt.Printf("Partition:    %s\n", obj.Partition.Uuid)
-	fmt.Printf("Object type:  %s\n", obj.ObjectType.Code)
+	fmt.Printf("Partition:    %s\n", obj.Partition)
+	fmt.Printf("Object type:  %s\n", obj.ObjectType)
 	fmt.Printf("Key:          %s\n", obj.Key)
-	fmt.Printf("Version:      %d\n", obj.Version)
 	fmt.Printf("Schema:\n%s\n", obj.Schema)
 }

--- a/cmd/runm/commands/property_schema_list.go
+++ b/cmd/runm/commands/property_schema_list.go
@@ -1,10 +1,8 @@
 package commands
 
 import (
-	"fmt"
 	"io"
 	"os"
-	"strconv"
 
 	"golang.org/x/net/context"
 
@@ -48,31 +46,15 @@ func propertySchemaList(cmd *cobra.Command, args []string) {
 		"Partition",
 		"Object Type",
 		"Key",
-		"Version",
 		"Schema",
 	}
 	rows := make([][]string, len(msgs))
-	for x, msg := range msgs {
-		partition := ""
-		if msg.Partition != nil {
-			partition = fmt.Sprintf(
-				"%s",
-				msg.Partition.DisplayName,
-			)
-		}
-		objType := ""
-		if msg.ObjectType != nil {
-			objType = fmt.Sprintf(
-				"%s",
-				msg.ObjectType.Code,
-			)
-		}
+	for x, obj := range msgs {
 		rows[x] = []string{
-			partition,
-			objType,
-			msg.Key,
-			strconv.Itoa(int(msg.Version)),
-			msg.Schema,
+			obj.Partition,
+			obj.ObjectType,
+			obj.Key,
+			obj.Schema,
 		}
 	}
 	table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/runm/commands/property_schema_set.go
+++ b/cmd/runm/commands/property_schema_set.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"golang.org/x/net/context"
+
+	pb "github.com/runmachine-io/runmachine/proto"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// YAML document we will read stdin or the -f option's value
+	propSchemaDoc string
+	// optional filepath to read the object file containing the schema from
+	propSchemaDocPath string
+)
+
+var propertySchemaSetCommand = &cobra.Command{
+	Use:   "set",
+	Short: "Create or update a property schema",
+	Run:   propertySchemaSet,
+}
+
+func setupPropertySchemaSetFlags() {
+	propertySchemaSetCommand.Flags().StringVarP(
+		&propSchemaDocPath,
+		"file", "f",
+		"",
+		"optional filepath to property schema document to send.",
+	)
+}
+
+func init() {
+	setupPropertySchemaSetFlags()
+}
+
+// propertySchemaProcessStdin reads the supplied buffer which contains a YAML
+// document describing the property schema to create or update, and returns a
+// pointer to PropertySchemaSetFields protobuffer message containing the fields
+// to set on the new (or changed) object.
+func getPropertySchemaFromFile(b []byte) (*pb.PropertySchema, error) {
+	return &pb.PropertySchema{}, nil
+}
+
+func propertySchemaSet(cmd *cobra.Command, args []string) {
+	conn := connect()
+	defer conn.Close()
+
+	var b []byte
+	if propSchemaDocPath == "" {
+		// User did not specify -f therefore we expect to read the property
+		// schema YAML document from stdin
+		scanner := bufio.NewScanner(os.Stdin)
+		buf := make([]byte, 0)
+		for scanner.Scan() {
+			buf = append(buf, scanner.Bytes()...)
+		}
+		b = buf
+	} else {
+		if buf, err := ioutil.ReadFile(propSchemaDocPath); err != nil {
+			fmt.Printf("Error: %s\n", err)
+			os.Exit(1)
+		} else {
+			b = buf
+		}
+	}
+
+	if len(b) == 0 {
+		fmt.Println("Error: expected to receive property schema YAML in STDIN")
+		os.Exit(1)
+	}
+
+	obj, err := getPropertySchemaFromFile(b)
+	if err != nil {
+		fmt.Printf("Error: failed to parse property schema YAML document: %s\n", err)
+		os.Exit(1)
+	}
+
+	client := pb.NewRunmMetadataClient(conn)
+	req := &pb.PropertySchemaSetRequest{
+		Session:        getSession(),
+		PropertySchema: obj,
+	}
+
+	resp, err := client.PropertySchemaSet(context.Background(), req)
+	exitIfError(err)
+	obj = resp.PropertySchema
+	if !quiet {
+		fmt.Printf("Successfully created property schema\n")
+		if verbose {
+			fmt.Printf("Partition:    %s\n", obj.Partition)
+			fmt.Printf("Object type:  %s\n", obj.ObjectType)
+			fmt.Printf("Key:          %s\n", obj.Key)
+			fmt.Printf("Schema:\n%s\n", obj.Schema)
+		}
+	}
+}

--- a/pkg/metadata/property.go
+++ b/pkg/metadata/property.go
@@ -28,6 +28,18 @@ var (
 		codes.FailedPrecondition,
 		"object type is required.",
 	)
+	ErrPropertyKeyRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"property key is required.",
+	)
+	ErrSchemaRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"schema is required.",
+	)
+	ErrPropertySchemaObjectRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"property schema object is required.",
+	)
 )
 
 func (s *Server) PropertySchemaDelete(
@@ -43,29 +55,21 @@ func (s *Server) PropertySchemaGet(
 	ctx context.Context,
 	req *pb.PropertySchemaGetRequest,
 ) (*pb.PropertySchema, error) {
-	if req.ObjectType == nil {
+	if req.ObjectType == "" {
 		return nil, ErrObjectTypeRequired
 	}
-	version := uint32(1)
-	if req.Version != nil {
-		version = req.Version.Value
+	if req.Partition == "" {
+		return nil, ErrPartitionRequired
 	}
-	var partition string
-	if req.Partition != nil {
-		// TODO(jaypipes): AUTHZ check user can specify partition
-		partition = req.Partition.Uuid
-	} else {
-		if req.Session.Partition == nil {
-			return nil, ErrPartitionRequired
-		}
-		partition = req.Session.Partition.Uuid
+	if req.Key == "" {
+		return nil, ErrPropertyKeyRequired
 	}
-	// TODO(jaypipes): Validate the supplied object type even exists
+	// TODO(jaypipes): AUTHZ check user can specify partition
+	// TODO(jaypipes): AUTHZ check user can read property schemas
 	obj, err := s.store.PropertySchemaGet(
-		partition,
-		req.ObjectType.Code,
+		req.Partition,
+		req.ObjectType,
 		req.Key,
-		version,
 	)
 	if err != nil {
 		if err == errors.ErrNotFound {
@@ -102,5 +106,85 @@ func (s *Server) PropertySchemaSet(
 	ctx context.Context,
 	req *pb.PropertySchemaSetRequest,
 ) (*pb.PropertySchemaSetResponse, error) {
+	// TODO(jaypipes): AUTHZ check for writing property schemas
+	if req.PropertySchema == nil {
+		return nil, ErrPropertySchemaObjectRequired
+	}
+
+	// First, validate the supplied property schema has the required fields.
+	obj := req.PropertySchema
+
+	if obj.Partition == "" {
+		return nil, ErrPartitionRequired
+	}
+
+	if obj.ObjectType == "" {
+		return nil, ErrObjectTypeRequired
+	}
+
+	if obj.Key == "" {
+		return nil, ErrPropertyKeyRequired
+	}
+
+	if obj.Schema == "" {
+		return nil, ErrSchemaRequired
+	} else {
+		// TODO(jaypipes): Validate the schema document provided
+		s.log.L3("Validating property schema")
+	}
+
+	// TODO(jaypipes): AUTHZ check user can specify partition
+
+	partition := obj.Partition
+	objType := obj.ObjectType
+	propKey := obj.Key
+
+	existing, err := s.store.PropertySchemaGet(partition, objType, propKey)
+	if err != nil {
+		if err != ErrNotFound {
+			s.log.ERR(
+				"Failed trying to find existing property schema for %s:%s:%s: %s",
+				partition,
+				objType,
+				propKey,
+			)
+			// NOTE(jaypipes): we don't return internal errors
+			return nil, ErrUnknown
+		}
+	}
+
+	if existing == nil {
+		s.log.L3("Creating new property schema %s:%s:%s", partition, objType, propKey)
+
+		// Set default access permissions to read/write by any role in the
+		// creating project
+		if obj.AccessPermissions == nil {
+			obj.AccessPermissions = []*pb.PropertyAccessPermission{
+				&pb.PropertyAccessPermission{
+					Project: &pb.StringValue{
+						Value: req.Session.Project,
+					},
+					Permission: pb.AccessPermission_READ_WRITE,
+				},
+			}
+		}
+
+		// TODO(jaypipes): Make sure that the project that created the property
+		// schema can read and write it
+
+		if err := s.store.PropertySchemaCreate(obj); err != nil {
+			return nil, err
+		}
+		resp := &pb.PropertySchemaSetResponse{
+			PropertySchema: obj,
+		}
+		s.log.L1("Created new property schema %s:%s:%s", partition, objType, propKey)
+		return resp, nil
+	}
+
+	s.log.L3("Updating property schema %s:%s:%s", partition, objType, propKey)
+
+	// TODO(jaypipes): Update the property schema...
+
 	return nil, nil
 }

--- a/pkg/metadata/server.go
+++ b/pkg/metadata/server.go
@@ -10,6 +10,10 @@ import (
 	"github.com/runmachine-io/runmachine/pkg/metadata/storage"
 )
 
+var (
+	ErrBadInput = fmt.Errorf("Bad input. Check response.Errors for more information")
+)
+
 type Server struct {
 	log      *logging.Logs
 	cfg      *config.Config

--- a/proto/defs/property.proto
+++ b/proto/defs/property.proto
@@ -44,16 +44,22 @@ message PropertyAccessPermission {
 // }
 //
 // The adminstrator would then save a PropertySchema message with an
-// object_type of "image", a key of "application_code", a version of 1, and a
-// schema of the above serialized JSONSchema document.
+// object_type of "image", a key of "application_code", and a schema of the
+// above serialized JSONSchema document.
 //
 // Once saved to the property service, the "application_type" property item
 // values would be validated against the above schema before being stored.
 message PropertySchema {
-    Partition partition = 1;
-    ObjectType object_type = 2;
+    // UUID of the partition this property schema has been created in
+    string partition = 1;
+    // String code of the object type the property schema applies to. e.g.
+    // "runm.machine"
+    string object_type = 2;
+    // The property key to apply the property schema to. e.g. "architecture"
     string key = 3;
-    uint32 version = 4;
-    string schema = 5;
+    // a YAML document describing the format and type constraints of the value
+    // of the property
+    string schema = 4;
+    // Collection of access permissions applied to this property schema
     repeated PropertyAccessPermission access_permissions = 50;
 }

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -165,34 +165,23 @@ message ObjectDeleteResponse {
 
 message PropertySchemaGetRequest {
     Session session = 1;
-    // If nil, we use the session's partition
-    Partition partition = 2;
-    ObjectType object_type = 3;
+    string partition = 2;
+    string object_type = 3;
     string key = 4;
-    UInt32Value version = 5;
-}
-
-message PropertySchemaSetFields {
-    Partition partition = 1;
-    ObjectType object_type = 2;
-    StringValue key = 3;
-    StringValue schema = 4;
 }
 
 message PropertySchemaSetRequest {
     Session session = 1;
     PropertySchema property_schema = 2;
-    PropertySchemaSetFields changed = 3;
 }
 
 message PropertySchemaSetResponse {
-    repeated Error errors = 1;
     PropertySchema property_schema = 2;
 }
 
 message PropertySchemaListFilters {
-    repeated Partition partitions = 1;
-    repeated ObjectType object_types = 2;
+    repeated string partitions = 1;
+    repeated string object_types = 2;
     repeated string keys = 3;
 }
 

--- a/scripts/exec-runm-command.sh
+++ b/scripts/exec-runm-command.sh
@@ -18,7 +18,7 @@ if debug_enabled; then
     set -o xtrace
 fi
 
-docker image inspect runm-metadata:$VERSION >/dev/null 2>&1
+docker image inspect runm/metadata:$VERSION >/dev/null 2>&1
 if [ $? -ne 0 ]; then
     make build
 fi
@@ -47,7 +47,7 @@ if ! container_is_running "$METADATA_CONTAINER_NAME"; then
         -e RUNM_LOG_LEVEL=3 \
         -e RUNM_METADATA_STORAGE_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
         -e RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX="$METADATA_CONTAINER_NAME" \
-        runm-metadata:$VERSION >/dev/null 2>&1
+        runm/metadata:$VERSION >/dev/null 2>&1
     print_if_verbose "ok."
 fi
 
@@ -66,4 +66,4 @@ print_if_verbose "Running \`runm $EXEC_COMMAND\` in single-use docker container.
 print_if_verbose "*********************************************************************"
 print_if_verbose ""
 
-docker run --rm --network host runm:$VERSION runm $EXEC_COMMAND
+docker run --rm --network host runm/runm:$VERSION $EXEC_COMMAND


### PR DESCRIPTION
savepoint for work on `runm property-schema set`. Changes the
protobuffer model for PropertySchema to contain just the object type
code and partition UUID as a string instead of ObjectType and Partition
objects respectively. Also removes the version attribute of the property
schema since we're going to rely on etcd's generations to handle
concurrent writes.

Issue #21