### PR TITLE
metadata: `runm partition get/list`

### DIFF
--- a/cmd/runm/commands/partition.go
+++ b/cmd/runm/commands/partition.go
@@ -11,4 +11,5 @@ var partitionCommand = &cobra.Command{
 
 func init() {
 	partitionCommand.AddCommand(partitionListCommand)
+	partitionCommand.AddCommand(partitionGetCommand)
 }

--- a/cmd/runm/commands/partition.go
+++ b/cmd/runm/commands/partition.go
@@ -1,0 +1,14 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var partitionCommand = &cobra.Command{
+	Use:   "partition",
+	Short: "Fetch partition information",
+}
+
+func init() {
+	partitionCommand.AddCommand(partitionListCommand)
+}

--- a/cmd/runm/commands/partition_get.go
+++ b/cmd/runm/commands/partition_get.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	pb "github.com/runmachine-io/runmachine/proto"
+	"github.com/spf13/cobra"
+)
+
+var partitionGetCommand = &cobra.Command{
+	Use:   "get <search>",
+	Short: "Show information for a single partition",
+	Args:  cobra.ExactArgs(1),
+	Run:   partitionGet,
+}
+
+func partitionGet(cmd *cobra.Command, args []string) {
+	conn := connect()
+	defer conn.Close()
+
+	client := pb.NewRunmMetadataClient(conn)
+
+	session := getSession()
+
+	req := &pb.PartitionGetRequest{
+		Session: session,
+		Search:  args[0],
+	}
+	obj, err := client.PartitionGet(context.Background(), req)
+	exitIfError(err)
+	fmt.Printf("UUID: %s\n", obj.Uuid)
+	fmt.Printf("Name: %s\n", obj.Name)
+}

--- a/cmd/runm/commands/partition_list.go
+++ b/cmd/runm/commands/partition_list.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/net/context"
+
+	"github.com/olekukonko/tablewriter"
+	pb "github.com/runmachine-io/runmachine/proto"
+	"github.com/spf13/cobra"
+)
+
+var partitionListCommand = &cobra.Command{
+	Use:   "list",
+	Short: "List information about partitions",
+	Run:   partitionList,
+}
+
+func partitionList(cmd *cobra.Command, args []string) {
+	filters := &pb.PartitionListFilters{}
+	conn := connect()
+	defer conn.Close()
+
+	client := pb.NewRunmMetadataClient(conn)
+	req := &pb.PartitionListRequest{
+		Session: getSession(),
+		Filters: filters,
+	}
+	stream, err := client.PartitionList(context.Background(), req)
+	exitIfConnectErr(err)
+
+	msgs := make([]*pb.Partition, 0)
+	for {
+		role, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		exitIfError(err)
+		msgs = append(msgs, role)
+	}
+	if len(msgs) == 0 {
+		exitNoRecords()
+	}
+	headers := []string{
+		"UUID",
+		"Name",
+	}
+	rows := make([][]string, len(msgs))
+	for x, obj := range msgs {
+		rows[x] = []string{
+			obj.Uuid,
+			obj.Name,
+		}
+	}
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(headers)
+	table.AppendBulk(rows)
+	table.Render()
+}

--- a/cmd/runm/commands/root.go
+++ b/cmd/runm/commands/root.go
@@ -111,6 +111,7 @@ func init() {
 
 	RootCommand.AddCommand(helpEnvCommand)
 	RootCommand.AddCommand(propertySchemaCommand)
+	RootCommand.AddCommand(partitionCommand)
 	RootCommand.SilenceUsage = true
 
 	clientLog = log.New(ioutil.Discard, "", 0)

--- a/pkg/metadata/partition.go
+++ b/pkg/metadata/partition.go
@@ -1,0 +1,29 @@
+package metadata
+
+import (
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+// PartitionList streams zero or more Partition objects back to the client that
+// match a set of optional filters
+func (s *Server) PartitionList(
+	req *pb.PartitionListRequest,
+	stream pb.RunmMetadata_PartitionListServer,
+) error {
+	cur, err := s.store.PartitionList(req)
+	if err != nil {
+		return err
+	}
+	defer cur.Close()
+	var key string
+	var msg pb.Partition
+	for cur.Next() {
+		if err = cur.Scan(&key, &msg); err != nil {
+			return err
+		}
+		if err = stream.Send(&msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/metadata/storage/partition.go
+++ b/pkg/metadata/storage/partition.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	etcd "github.com/coreos/etcd/clientv3"
+	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
+
+	"github.com/runmachine-io/runmachine/pkg/abstract"
+	"github.com/runmachine-io/runmachine/pkg/cursor"
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+const (
+	_PARTITIONS_KEY = "partitions/"
+)
+
+func (s *Store) kvPartitions() etcd.KV {
+	// The $PARTITIONS key namespace is a shortcut to: $ROOT/partitions
+	return etcd_namespace.NewKV(s.kv, _PARTITIONS_KEY)
+}
+
+// PartitionList returns a cursor that may be used to iterate over Partition
+// protobuffer objects stored in etcd
+func (s *Store) PartitionList(
+	req *pb.PartitionListRequest,
+) (abstract.Cursor, error) {
+	kv := s.kvPartitions()
+	ctx, cancel := s.requestCtx()
+	defer cancel()
+	resp, err := kv.Get(
+		ctx,
+		"/",
+		etcd.WithPrefix(),
+		// TODO(jaypipes): Factor the sorting/limiting/pagination out into a
+		// separate utility
+		etcd.WithSort(etcd.SortByKey, etcd.SortAscend),
+	)
+	if err != nil {
+		s.log.ERR("error listing partitions: %v", err)
+		return nil, err
+	}
+
+	return cursor.NewEtcdPBCursor(resp), nil
+}

--- a/pkg/metadata/storage/partition.go
+++ b/pkg/metadata/storage/partition.go
@@ -1,11 +1,15 @@
 package storage
 
 import (
+	"fmt"
+
 	etcd "github.com/coreos/etcd/clientv3"
 	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/runmachine-io/runmachine/pkg/abstract"
 	"github.com/runmachine-io/runmachine/pkg/cursor"
+	"github.com/runmachine-io/runmachine/pkg/errors"
 	pb "github.com/runmachine-io/runmachine/proto"
 )
 
@@ -16,6 +20,37 @@ const (
 func (s *Store) kvPartitions() etcd.KV {
 	// The $PARTITIONS key namespace is a shortcut to: $ROOT/partitions
 	return etcd_namespace.NewKV(s.kv, _PARTITIONS_KEY)
+}
+
+// PartitionGet returns a Partition protobuffer message that has the UUID or
+// name of the supplied search string
+func (s *Store) PartitionGet(
+	search string,
+) (*pb.Partition, error) {
+	kv := s.kvPartitions()
+	ctx, cancel := s.requestCtx()
+	defer cancel()
+
+	// First try looking up the partition by UUID. If not, match, then we try
+	// the by-name index...
+	key := fmt.Sprintf("by-uuid/%s", search)
+	gr, err := kv.Get(ctx, key, etcd.WithPrefix())
+	if err != nil {
+		s.log.ERR("error getting key %s: %v", key, err)
+		return nil, err
+	}
+	nKeys := len(gr.Kvs)
+	if nKeys == 0 {
+		return nil, errors.ErrNotFound
+	} else if nKeys > 1 {
+		return nil, errors.ErrMultipleRecords
+	}
+	var obj *pb.Partition
+	if err = proto.Unmarshal(gr.Kvs[0].Value, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
 }
 
 // PartitionList returns a cursor that may be used to iterate over Partition

--- a/proto/defs/partition.proto
+++ b/proto/defs/partition.proto
@@ -9,6 +9,5 @@ package runm;
 // working with or have access to.
 message Partition {
     string uuid = 1;
-    string display_name = 2;
-    string slug = 3;
+    string name = 2;
 }

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -19,6 +19,13 @@ import "wrappers.proto";
 // administrator may create property schema items which dictate the required
 // format or type of a property's values.
 service RunmMetadata {
+    // Returns information about a specific partition
+    rpc partition_get(PartitionGetRequest) returns (Partition) {}
+
+    // Returns information about multiple partitions
+    rpc partition_list(PartitionListRequest) returns (
+        stream Partition) {}
+
     // Returns information about a specific object type
     rpc object_type_get(ObjectTypeGetRequest) returns (ObjectType) {}
 
@@ -75,6 +82,24 @@ service RunmMetadata {
 }
 
 // RPC Request payload messages
+message PartitionGetRequest {
+    Session session = 1;
+    // Simple string lookup. search may be a UUID or a human-readable name
+    string search = 2;
+}
+
+message PartitionListFilters {
+    // May be a UUID or a human-readable name. List multiple identifiers to
+    // filter on any of the supplied identifiers.
+    repeated string identifiers = 1;
+}
+
+message PartitionListRequest {
+    Session session = 1;
+    PartitionListFilters filters = 2;
+    SearchOptions options = 3;
+}
+
 message ObjectTypeGetRequest {
     Session session = 1;
     string search = 2;

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -19,9 +19,6 @@ import "wrappers.proto";
 // administrator may create property schema items which dictate the required
 // format or type of a property's values.
 service RunmMetadata {
-    // Returns information about a specific partition
-    rpc partition_get(PartitionGetRequest) returns (Partition) {}
-
     // Returns information about multiple partitions
     rpc partition_list(PartitionListRequest) returns (
         stream Partition) {}
@@ -79,13 +76,6 @@ service RunmMetadata {
     // Returns property items for an object
     rpc object_properties_list(ObjectPropertiesListRequest) returns (
         stream Property) {}
-}
-
-// RPC Request payload messages
-message PartitionGetRequest {
-    Session session = 1;
-    // Simple string lookup. search may be a UUID or a human-readable name
-    string search = 2;
 }
 
 message PartitionListFilters {

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -19,6 +19,9 @@ import "wrappers.proto";
 // administrator may create property schema items which dictate the required
 // format or type of a property's values.
 service RunmMetadata {
+    // Returns information about a specific partition
+    rpc partition_get(PartitionGetRequest) returns (Partition) {}
+
     // Returns information about multiple partitions
     rpc partition_list(PartitionListRequest) returns (
         stream Partition) {}
@@ -76,6 +79,11 @@ service RunmMetadata {
     // Returns property items for an object
     rpc object_properties_list(ObjectPropertiesListRequest) returns (
         stream Property) {}
+}
+
+message PartitionGetRequest {
+    Session session = 1;
+    string search = 2;
 }
 
 message PartitionListFilters {


### PR DESCRIPTION
Adds support for getting a single partition information and listing partitions in the `runm` CLI program along with all the server and storage layer support.

Issue #25 