### PR TITLE
allow bootstrapping a new partition in `runm-metadata`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,6 +44,12 @@
   version = "v1.2.0"
 
 [[projects]]
+  name = "github.com/google/uuid"
+  packages = ["."]
+  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -181,6 +187,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "589360ebe9a180aba9127603d3492434415dc1486cd739f3ccfe4d5a060d8970"
+  inputs-digest = "8a12565a8c64b42c9dc6dd975b69108d26ae370021553b514503a91fc05f1af1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -68,3 +68,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/google/uuid"
+  version = "1.0.0"

--- a/pkg/metadata/bootstrap.go
+++ b/pkg/metadata/bootstrap.go
@@ -1,0 +1,34 @@
+package metadata
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+func (s *Server) Bootstrap(
+	ctx context.Context,
+	req *pb.BootstrapRequest,
+) (*pb.BootstrapResponse, error) {
+	token := req.BootstrapToken
+	partName := req.PartitionName
+	var partUuid string
+	if req.PartitionUuid == nil {
+		partUuid = uuid.New().String()
+	} else {
+		partUuid = req.PartitionUuid.Value
+	}
+
+	partUuid = normalizeUuid(partUuid)
+
+	if err := s.store.Bootstrap(token, partName, partUuid); err != nil {
+		return nil, err
+	}
+	return &pb.BootstrapResponse{
+		Partition: &pb.Partition{
+			Name: partName,
+			Uuid: partUuid,
+		},
+	}, nil
+}

--- a/pkg/metadata/storage/bootstrap.go
+++ b/pkg/metadata/storage/bootstrap.go
@@ -13,12 +13,6 @@ import (
 const (
 	// The one-time-use bootstrap token is stored here
 	_BOOTSTRAP_KEY = "bootstrap"
-	// The index into partition UUIDs by name
-	_PARTITIONS_BY_NAME_KEY = "partitions/by-name/%s"
-	// The index into Partition protobuffer objects by UUID
-	// $PARTITION refers to the key namespace at
-	// $ROOT/partitions/by-uuid/{partition_uuid}
-	_PARTITIONS_BY_UUID_KEY = "partitions/by-uuid/%s/"
 )
 
 var (
@@ -56,12 +50,12 @@ func (s *Store) keyNamespaceExists(
 	kv etcd.KV,
 	ns string,
 ) (bool, error) {
-	gr, err := kv.Get(ctx, ns, etcd.WithPrefix())
+	gr, err := kv.Get(ctx, ns, etcd.WithPrefix(), etcd.WithCountOnly())
 	if err != nil {
 		s.log.ERR("error getting key namespace %s: %v", ns, err)
 		return false, err
 	}
-	return (len(gr.Kvs) > 0), nil
+	return (gr.Count > 0), nil
 }
 
 // createKeyNamespace creates the supplied key namespace. If the namespace

--- a/pkg/metadata/storage/bootstrap.go
+++ b/pkg/metadata/storage/bootstrap.go
@@ -2,30 +2,53 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
 	etcd "github.com/coreos/etcd/clientv3"
+	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
+	"github.com/gogo/protobuf/proto"
+	pb "github.com/runmachine-io/runmachine/proto"
 )
 
-// bootstrap is responsible for creating the etcd key namespace layout that the
+const (
+	// The one-time-use bootstrap token is stored here
+	_BOOTSTRAP_KEY = "bootstrap"
+	// The index into partition UUIDs by name
+	_PARTITIONS_BY_NAME_KEY = "partitions/by-name/%s"
+	// The index into Partition protobuffer objects by UUID
+	// $PARTITION refers to the key namespace at
+	// $ROOT/partitions/by-uuid/{partition_uuid}
+	_PARTITIONS_BY_UUID_KEY = "partitions/by-uuid/%s/"
+)
+
+var (
+	ErrBootstrapFailed = fmt.Errorf("Bootstrap failed.")
+)
+
+// init is responsible for creating the etcd key namespace layout that the
 // `runm-metadata` service uses to store and fetch information about the
 // objects in the system.
-func (s *Store) bootstrap(ctx context.Context) error {
+func (s *Store) init(ctx context.Context) error {
 	// ensure that we have the $ROOT key namespace created
 	rootNs := "/"
 	rootExists, err := s.keyNamespaceExists(ctx, s.kv, rootNs)
 	if err != nil {
 		return err
 	} else if !rootExists {
-		s.log.L3("bootstrapping: root namespace does not exist. creating...")
+		s.log.L3("init: root namespace does not exist. creating...")
 		if err = s.keyNamespaceCreate(ctx, s.kv, rootNs); err != nil {
 			return err
 		}
-		s.log.L3("bootstrapping: root namespace created")
+		s.log.L3("init: root namespace created")
 	} else {
-		s.log.L3("bootstrapping: root namespace already exists")
+		s.log.L3("init: root namespace already exists")
 	}
-	s.bootstrapped = true
 	return nil
+}
+
+func (s *Store) kvPartition(partition string) etcd.KV {
+	key := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partition)
+	return etcd_namespace.NewKV(s.kv, key)
 }
 
 func (s *Store) keyNamespaceExists(
@@ -60,6 +83,82 @@ func (s *Store) keyNamespaceCreate(
 		return err
 	} else if resp.Succeeded == false {
 		s.log.L3("another thread already created namespace %s. ignoring...", ns)
+	}
+	return nil
+}
+
+// keyHasValue returns true if the supplied key exists and has the supplied
+// value, false otherwise
+func (s *Store) keyHasValue(
+	ctx context.Context,
+	kv etcd.KV,
+	key string,
+	value string,
+) bool {
+	gr, err := kv.Get(ctx, key)
+	if err != nil {
+		s.log.ERR("error getting key %s: %v", key, err)
+		return false
+	}
+	if len(gr.Kvs) != 1 {
+		return false
+	}
+	return string(gr.Kvs[0].Value) == value
+}
+
+// Bootstrap allows unauthenticated users to create a partition in the
+// runm-metadata service if they know the value of a one-time bootstrap token
+func (s *Store) Bootstrap(
+	token string,
+	partName string,
+	partUuid string,
+) error {
+	ctx, cancel := s.requestCtx()
+	defer cancel()
+
+	// Do a quick check that the bootstrap token exists and has the same value
+	// as the supplied token. If not, log a message and return a generic error.
+	if !s.keyHasValue(ctx, s.kv, _BOOTSTRAP_KEY, token) {
+		s.log.ERR("bootstrap: bootstrap key does not exist or wrong value supplied for token")
+		return ErrBootstrapFailed
+	}
+
+	partByNameKey := fmt.Sprintf(_PARTITIONS_BY_NAME_KEY, partName)
+	partByUuidKey := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partUuid)
+
+	partValue := proto.MarshalTextString(
+		&pb.Partition{
+			Name: partName,
+			Uuid: partUuid,
+		},
+	)
+
+	// creates the partition keys and deletes the one-time bootstrap token
+	// using a transaction that ensures if another thread modified anything
+	// underneath us, we return an error
+	then := []etcd.Op{
+		// Add the entry for the index by partition name
+		etcd.OpPut(partByNameKey, partUuid),
+		// Add the entry for the index by partition UUID
+		etcd.OpPut(partByNameKey, partValue),
+		// And remove the one-time-use bootstrap token/key
+		etcd.OpDelete(_BOOTSTRAP_KEY),
+	}
+	compare := []etcd.Cmp{
+		// Ensure the partition value and index by name don't yet exist
+		etcd.Compare(etcd.Version(partByNameKey), "=", 0),
+		etcd.Compare(etcd.Version(partByUuidKey), "=", 0),
+		// Ensure the bootstrap token exists and is what we supplied
+		etcd.Compare(etcd.Value(_BOOTSTRAP_KEY), "=", token),
+	}
+	resp, err := s.kv.Txn(ctx).If(compare...).Then(then...).Commit()
+
+	if err != nil {
+		s.log.ERR("bootstrap: failed to create txn in etcd: %v", err)
+		return ErrBootstrapFailed
+	} else if resp.Succeeded == false {
+		s.log.L3("bootstrap: another thread bootstrapped")
+		return ErrBootstrapFailed
 	}
 	return nil
 }

--- a/pkg/metadata/storage/partition.go
+++ b/pkg/metadata/storage/partition.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	etcd "github.com/coreos/etcd/clientv3"
-	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/runmachine-io/runmachine/pkg/abstract"
@@ -14,39 +13,67 @@ import (
 )
 
 const (
+	// The key namespace with partition-specific information. Has two sub key
+	// namespaces, one is an index on the partition's name with valued keys
+	// pointing to UUIDs of that partition. The other is a set of valued keys
+	// listed by UUID with values containing Partition protobuffer records.
 	_PARTITIONS_KEY = "partitions/"
+	// The index into partition UUIDs by name
+	_PARTITIONS_BY_NAME_KEY = "partitions/by-name/%s"
+	// The index into Partition protobuffer objects by UUID
+	// $PARTITION refers to the key namespace at
+	// $ROOT/partitions/by-uuid/{partition_uuid}
+	_PARTITIONS_BY_UUID_KEY = "partitions/by-uuid/%s"
 )
-
-func (s *Store) kvPartitions() etcd.KV {
-	// The $PARTITIONS key namespace is a shortcut to: $ROOT/partitions
-	return etcd_namespace.NewKV(s.kv, _PARTITIONS_KEY)
-}
 
 // PartitionGet returns a Partition protobuffer message that has the UUID or
 // name of the supplied search string
 func (s *Store) PartitionGet(
 	search string,
 ) (*pb.Partition, error) {
-	kv := s.kvPartitions()
 	ctx, cancel := s.requestCtx()
 	defer cancel()
 
+	// TODO(jaypipes): This is going to be a common pattern (look up by UUID,
+	// fall back to looking up by name index and following the index pointer to
+	// the UUID data record. Look for a way to DRY this up
+
 	// First try looking up the partition by UUID. If not, match, then we try
 	// the by-name index...
-	key := fmt.Sprintf("by-uuid/%s", search)
-	gr, err := kv.Get(ctx, key, etcd.WithPrefix())
+	byUuidKey := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, search)
+	grByUuid, err := s.kv.Get(ctx, byUuidKey)
 	if err != nil {
-		s.log.ERR("error getting key %s: %v", key, err)
+		s.log.ERR("error getting key %s: %v", byUuidKey, err)
 		return nil, err
 	}
-	nKeys := len(gr.Kvs)
-	if nKeys == 0 {
-		return nil, errors.ErrNotFound
-	} else if nKeys > 1 {
-		return nil, errors.ErrMultipleRecords
+
+	if grByUuid.Count == 0 {
+		byNameKey := fmt.Sprintf(_PARTITIONS_BY_NAME_KEY, search)
+		grByName, err := s.kv.Get(ctx, byNameKey)
+		if err != nil {
+			s.log.ERR("error getting key %s: %v", byNameKey, err)
+			return nil, err
+		}
+		if grByName.Count == 0 {
+			return nil, errors.ErrNotFound
+		}
+		partUuid := grByName.Kvs[0].Value
+		byUuidKey = fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partUuid)
+		grByUuid, err = s.kv.Get(ctx, byUuidKey)
+		if err != nil {
+			s.log.ERR("error getting key %s: %v", byUuidKey, err)
+			return nil, err
+		}
+
+		if grByUuid.Count == 0 {
+			// NOTE(jaypipes): This is a major data corruption, since we have
+			// an index record by the partition name pointing to this UUID but
+			// no data record for the UUID...
+			s.log.ERR("DATA CORRUPTION! %s exists but no data record at %s", byNameKey, byUuidKey)
+		}
 	}
-	var obj *pb.Partition
-	if err = proto.Unmarshal(gr.Kvs[0].Value, obj); err != nil {
+	obj := &pb.Partition{}
+	if err = proto.Unmarshal(grByUuid.Kvs[0].Value, obj); err != nil {
 		return nil, err
 	}
 
@@ -58,12 +85,12 @@ func (s *Store) PartitionGet(
 func (s *Store) PartitionList(
 	req *pb.PartitionListRequest,
 ) (abstract.Cursor, error) {
-	kv := s.kvPartitions()
 	ctx, cancel := s.requestCtx()
 	defer cancel()
-	resp, err := kv.Get(
+
+	resp, err := s.kv.Get(
 		ctx,
-		"/",
+		_PARTITIONS_KEY,
 		etcd.WithPrefix(),
 		// TODO(jaypipes): Factor the sorting/limiting/pagination out into a
 		// separate utility

--- a/pkg/metadata/storage/store.go
+++ b/pkg/metadata/storage/store.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"fmt"
 
 	etcd "github.com/coreos/etcd/clientv3"
 	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
@@ -19,18 +18,13 @@ const (
 
 	// Used when creating empty leaf-level keys or key namespaces
 	_NO_VALUE = ""
-
-	// $PARTITION refers to the key namespace at
-	// $ROOT/partitions/by-uuid/{partition_uuid}
-	_PARTITIONS_BY_UUID_KEY = "partitions/by-uuid/%s/"
 )
 
 type Store struct {
-	log          *logging.Logs
-	cfg          *config.Config
-	client       *etcd.Client
-	kv           etcd.KV
-	bootstrapped bool
+	log    *logging.Logs
+	cfg    *config.Config
+	client *etcd.Client
+	kv     etcd.KV
 }
 
 func New(log *logging.Logs, cfg *config.Config) (*Store, error) {
@@ -46,15 +40,10 @@ func New(log *logging.Logs, cfg *config.Config) (*Store, error) {
 	}
 	ctx, cancel := s.requestCtx()
 	defer cancel()
-	if err = s.bootstrap(ctx); err != nil {
+	if err = s.init(ctx); err != nil {
 		return nil, err
 	}
 	return s, nil
-}
-
-func (s *Store) kvPartition(partition string) etcd.KV {
-	key := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partition)
-	return etcd_namespace.NewKV(s.kv, key)
 }
 
 func (s *Store) requestCtx() (context.Context, context.CancelFunc) {

--- a/pkg/metadata/util.go
+++ b/pkg/metadata/util.go
@@ -1,0 +1,9 @@
+package metadata
+
+import "strings"
+
+// normalizeUuid simple lowecases and removes all non-alphanumeric characters
+// from the supplied string
+func normalizeUuid(subject string) string {
+	return strings.ToLower(strings.Replace(subject, "-", "", -1))
+}

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -19,6 +19,10 @@ import "wrappers.proto";
 // administrator may create property schema items which dictate the required
 // format or type of a property's values.
 service RunmMetadata {
+    // Creates minimal information for service to run, including a name for a
+    // partition.
+    rpc bootstrap(BootstrapRequest) returns (BootstrapResponse) {}
+
     // Returns information about a specific partition
     rpc partition_get(PartitionGetRequest) returns (Partition) {}
 
@@ -79,6 +83,23 @@ service RunmMetadata {
     // Returns property items for an object
     rpc object_properties_list(ObjectPropertiesListRequest) returns (
         stream Property) {}
+}
+
+message BootstrapRequest {
+    // The value of the one-time bootstrap token. This must match exactly the
+    // value of the `--bootstrap-token` used when starting the metadata service
+    // and this is destroyed at the successful execution of a bootstrap
+    // operation.
+    string bootstrap_token = 1;
+    // A human-readable name for the partition you want to ensure exists
+    string partition_name = 2;
+    // Useful if you want to pre-determine partition UUIDs or during testing
+    StringValue partition_uuid = 3;
+}
+
+message BootstrapResponse {
+    // The partition that was created as part of the bootstrap process
+    Partition partition = 1;
 }
 
 message PartitionGetRequest {

--- a/scripts/dump-etcd.sh
+++ b/scripts/dump-etcd.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Dumps the contents of an etcd data store's keys. Accepts a single optional
+# CLI argument of the key prefix to filter results by.
+
+DEBUG=${DEBUG:-0}
+VERBOSE=${VERBOSE:-0}
+ROOT_DIR=$(cd $(dirname "$0")/.. && pwd)
+SCRIPTS_DIR=$ROOT_DIR/scripts
+LIB_DIR=$SCRIPTS_DIR/lib
+
+source $LIB_DIR/common
+
+check_is_installed docker
+
+source $LIB_DIR/container
+source $LIB_DIR/etcd
+
+if debug_enabled; then
+    set -o xtrace
+fi
+
+EXEC_COMMAND="$@"
+ETCD_CONTAINER_NAME=${ETCD_CONTAINER_NAME:-"runm-test-etcd"}
+
+if ! container_is_running "$ETCD_CONTAINER_NAME"; then
+    $SCRIPTS_DIR/start-etcd-container.sh "$ETCD_CONTAINER_NAME"
+fi
+
+if ! container_get_ip "$ETCD_CONTAINER_NAME" etcd_container_ip; then
+    echo "ERROR: could not get IP for etcd container"
+    exit 1
+fi
+
+key_prefix=${1:-"/"}
+
+etcd_results=$(
+    KEY=`echo "$key_prefix" | base64`; curl -LsS -X POST -d "{\"key\": \"$KEY\", \"range_end\": \"AA==\"}" \
+       http://$etcd_container_ip:2379/v3alpha/kv/range | \
+       python -mjson.tool | \
+       grep "key" | \
+       cut -d':' -f2 \
+       | tr -d ' ",'
+)
+for payload in $etcd_results; do
+        echo $payload | base64 --decode; echo "";
+done

--- a/scripts/exec-runm-command.sh
+++ b/scripts/exec-runm-command.sh
@@ -47,6 +47,7 @@ if ! container_is_running "$METADATA_CONTAINER_NAME"; then
         -e RUNM_LOG_LEVEL=3 \
         -e RUNM_METADATA_STORAGE_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
         -e RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX="$METADATA_CONTAINER_NAME" \
+        -e RUNM_METADATA_BOOTSTRAP_TOKEN="bootstrapme" \
         runm/metadata:$VERSION >/dev/null 2>&1
     print_if_verbose "ok."
 fi


### PR DESCRIPTION
Adds a new gRPC API method to the `runm-metadata` service that allows a user to create a new partition without being authenticated simply by passing a one-time-use bootstrap token to the server.

Upon startup, the `runm-metadata` server checks to see if a `--bootstrap-token` has been supplied as a CLI argument. If so, it ensures that a bootstrap token entry is created in the underlying etcd data store. When the user issues a `runm bootstrap --partition <NAME> --bootstrap-token <TOKEN>` call, an etcd transaction is executed that creates the `$ROOT/partitions/by-name/<NAME>` key (with a value of the partition UUID), creates the `$ROOT/partitions/by-uuid/<UUID>` key (with a value of the `Partition` protobuffer object, and deletes the one-time-use bootstrap token.

Still left TODO is to wire up the `runm bootstrap` command.

Issue #30 