### PR TITLE
add `runm bootstrap` CLI command

### DIFF
--- a/cmd/runm/commands/bootstrap.go
+++ b/cmd/runm/commands/bootstrap.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	pb "github.com/runmachine-io/runmachine/proto"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Value of the bootstrap token the user provided
+	bootstrapToken string
+	// Human-readable name for the partition to create
+	bootstrapPartitionName string
+	// Optional UUID for the partition to create
+	bootstrapPartitionUuid string
+)
+
+var bootstrapCommand = &cobra.Command{
+	Use:   "bootstrap <token> <partition_name>",
+	Short: "Bootstrap using a one-time-use token. Creates a new partition.",
+	Args:  cobra.ExactArgs(2),
+	Run:   bootstrap,
+}
+
+func setupBootstrapFlags() {
+	bootstrapCommand.Flags().StringVarP(
+		&bootstrapPartitionUuid,
+		"partition-uuid", "",
+		"",
+		"Optional UUID of the partition to create.",
+	)
+}
+
+func init() {
+	setupBootstrapFlags()
+}
+
+func bootstrap(cmd *cobra.Command, args []string) {
+	conn := connect()
+	defer conn.Close()
+
+	client := pb.NewRunmMetadataClient(conn)
+	req := &pb.BootstrapRequest{
+		BootstrapToken: args[0],
+		PartitionName:  args[1],
+	}
+
+	if bootstrapPartitionUuid != "" {
+		req.PartitionUuid = &pb.StringValue{Value: bootstrapPartitionUuid}
+	}
+
+	resp, err := client.Bootstrap(context.Background(), req)
+	exitIfError(err)
+	obj := resp.Partition
+	fmt.Println(obj.Uuid)
+}

--- a/cmd/runm/commands/root.go
+++ b/cmd/runm/commands/root.go
@@ -110,6 +110,7 @@ func init() {
 	addConnectFlags()
 
 	RootCommand.AddCommand(helpEnvCommand)
+	RootCommand.AddCommand(bootstrapCommand)
 	RootCommand.AddCommand(propertySchemaCommand)
 	RootCommand.AddCommand(partitionCommand)
 	RootCommand.SilenceUsage = true

--- a/pkg/metadata/bootstrap.go
+++ b/pkg/metadata/bootstrap.go
@@ -5,6 +5,19 @@ import (
 
 	"github.com/google/uuid"
 	pb "github.com/runmachine-io/runmachine/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	ErrBootstrapTokenRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"bootstrap token is required.",
+	)
+	ErrPartitionNameRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"partition name is required.",
+	)
 )
 
 func (s *Server) Bootstrap(
@@ -12,14 +25,20 @@ func (s *Server) Bootstrap(
 	req *pb.BootstrapRequest,
 ) (*pb.BootstrapResponse, error) {
 	token := req.BootstrapToken
+	if token == "" {
+		return nil, ErrBootstrapTokenRequired
+	}
 	partName := req.PartitionName
+	if partName == "" {
+		return nil, ErrPartitionNameRequired
+	}
+
 	var partUuid string
 	if req.PartitionUuid == nil {
 		partUuid = uuid.New().String()
 	} else {
 		partUuid = req.PartitionUuid.Value
 	}
-
 	partUuid = normalizeUuid(partUuid)
 
 	if err := s.store.Bootstrap(token, partName, partUuid); err != nil {

--- a/pkg/metadata/storage/bootstrap.go
+++ b/pkg/metadata/storage/bootstrap.go
@@ -154,7 +154,7 @@ func (s *Store) Bootstrap(
 		// Add the entry for the index by partition name
 		etcd.OpPut(partByNameKey, partUuid),
 		// Add the entry for the index by partition UUID
-		etcd.OpPut(partByNameKey, partValue),
+		etcd.OpPut(partByUuidKey, partValue),
 		// And remove the one-time-use bootstrap token/key
 		etcd.OpDelete(_BOOTSTRAP_KEY),
 	}


### PR DESCRIPTION
Adds the client side of the bootstrap process, which creates a new
partition, supplying the one-time-use bootstrap token:

```
[jaypipes@uberbox runmachine]$ ./scripts/dump-etcd.sh
gsr/services/runmachine-metadata/172.17.0.3:10000
runm-test-metadata/runm-metadata//
runm-test-metadata/runm-metadata/bootstrap
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh bootstrap bootstrapme part0
1b561f953481442fb301a30f9c40994c
[jaypipes@uberbox runmachine]$ ./scripts/dump-etcd.sh
gsr/services/runmachine-metadata/172.17.0.3:10000
runm-test-metadata/runm-metadata//
runm-test-metadata/runm-metadata/partitions/by-name/part0
runm-test-metadata/runm-metadata/partitions/by-uuid/1b561f953481442fb301a30f9c40994c
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh bootstrap bootstrapme part0
Error: Bootstrap failed.
```

Note the bootstrap token is removed after successfully creating the
partition, and attempting to bootstrap again fails afterwards.

Issue #30