### PR TITLE
correct issues getting and listing partitions

### DIFF
--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -54,14 +54,14 @@ The root of the tree of keys in `etcd` used by the `runm-metadata` service
 always starts at the value designated by the
 `RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX` environs variable (or equivalent
 `--storage-etcd-key-prefix` command line option) and is followed by the
-constant `runm-metadata`.
+constant `runm/metadata`.
 
 So, for example, assuming that `RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX` is its
 default value of `/`. The top-level key namespace in `etcd` for all
-`runm-metadata` data would be the string `runm-metadata/`:
+`runm-metadata` data would be the string `runm/metadata/`:
 
 ```
-runm-metadata/
+runm/metadata/
 ```
 
 This value will be referred to as the `$ROOT` key namespace (or just `$ROOT`
@@ -69,7 +69,7 @@ for short) in this document.
 
 ### The `$ROOT` key namespace
 
-The keys directly Under `$ROOT` describe the known **partitions** in the
+The keys directly under `$ROOT` describe the known **partitions** in the
 system. It's easier to explain the structure by looking at a sample key
 namespace layout.
 

--- a/pkg/metadata/storage/bootstrap.go
+++ b/pkg/metadata/storage/bootstrap.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	etcd "github.com/coreos/etcd/clientv3"
-	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
 	"github.com/gogo/protobuf/proto"
 	pb "github.com/runmachine-io/runmachine/proto"
 )
@@ -19,84 +18,24 @@ var (
 	ErrBootstrapFailed = fmt.Errorf("Bootstrap failed.")
 )
 
-// init is responsible for creating the etcd key namespace layout that the
-// `runm-metadata` service uses to store and fetch information about the
-// objects in the system. It is also responsible for creating the one-time-use
-// bootstrap token if necessary.
-func (s *Store) init(ctx context.Context) error {
-	// ensure that we have the $ROOT key namespace created
-	rootNs := "/"
-	rootExists, err := s.keyNamespaceExists(ctx, s.kv, rootNs)
-	if err != nil {
-		return err
-	} else if !rootExists {
-		s.log.L3("init: root namespace does not exist. creating...")
-		if err = s.keyNamespaceCreate(ctx, s.kv, rootNs); err != nil {
-			return err
-		}
-		s.log.L2("init: root namespace created")
-	} else {
-		s.log.L3("init: root namespace already exists")
-	}
-
+// ensureBootstrap is responsible for creating the one-time-use bootstrap token
+// if necessary.
+func (s *Store) ensureBootstrap() error {
+	ctx, cancel := s.requestCtx()
+	defer cancel()
 	if s.cfg.BootstrapToken == "" {
-		s.log.L3("init: no bootstrap token specified. ensuring bootstrap token does not exist...")
-		ctx, cancel := s.requestCtx()
-		defer cancel()
-
+		s.log.L3("no bootstrap token specified. ensuring bootstrap token does not exist...")
 		if _, err := s.kv.Delete(ctx, _BOOTSTRAP_KEY); err != nil {
 			s.log.ERR("failed trying to delete the bootstrap key: %s", err)
+			return err
 		}
 	} else {
-		s.log.L3("init: ensuring bootstrap token...")
-		ctx, cancel := s.requestCtx()
-		defer cancel()
-
+		s.log.L3("ensuring bootstrap token...")
 		if _, err := s.kv.Put(ctx, _BOOTSTRAP_KEY, s.cfg.BootstrapToken); err != nil {
 			s.log.ERR("failed trying to create the bootstrap key: %s", err)
+			return err
 		}
-		s.log.L2("init: bootstrap token created")
-	}
-	return nil
-}
-
-func (s *Store) kvPartition(partition string) etcd.KV {
-	key := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partition)
-	return etcd_namespace.NewKV(s.kv, key)
-}
-
-func (s *Store) keyNamespaceExists(
-	ctx context.Context,
-	kv etcd.KV,
-	ns string,
-) (bool, error) {
-	gr, err := kv.Get(ctx, ns, etcd.WithPrefix(), etcd.WithCountOnly())
-	if err != nil {
-		s.log.ERR("error getting key namespace %s: %v", ns, err)
-		return false, err
-	}
-	return (gr.Count > 0), nil
-}
-
-// createKeyNamespace creates the supplied key namespace. If the namespace
-// already exists, or another thread creates it during execution, returns nil
-func (s *Store) keyNamespaceCreate(
-	ctx context.Context,
-	kv etcd.KV,
-	ns string,
-) error {
-	// create the key namespace using a transaction that ensures if another
-	// thread creates it underneath us, that we just ignore and return nil
-	onSuccess := etcd.OpPut(ns, _NO_VALUE)
-	// Ensure the key doesn't yet exist
-	compare := etcd.Compare(etcd.Version(ns), "=", 0)
-	resp, err := kv.Txn(ctx).If(compare).Then(onSuccess).Commit()
-
-	if err != nil {
-		s.log.ERR("failed to create txn in etcd: %v", err)
-		return err
-	} else if resp.Succeeded == false {
-		s.log.L3("another thread already created namespace %s. ignoring...", ns)
+		s.log.L2("bootstrap token created")
 	}
 	return nil
 }

--- a/pkg/metadata/storage/bootstrap.go
+++ b/pkg/metadata/storage/bootstrap.go
@@ -76,8 +76,8 @@ func (s *Store) Bootstrap(
 		return ErrBootstrapFailed
 	}
 
-	partByNameKey := fmt.Sprintf(_PARTITIONS_BY_NAME_KEY, partName)
-	partByUuidKey := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partUuid)
+	partByNameKey := _PARTITIONS_BY_NAME_KEY + partName
+	partByUuidKey := _PARTITIONS_BY_UUID_KEY + partUuid
 
 	partValue, err := proto.Marshal(
 		&pb.Partition{

--- a/pkg/metadata/storage/partition.go
+++ b/pkg/metadata/storage/partition.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	etcd "github.com/coreos/etcd/clientv3"
+	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/runmachine-io/runmachine/pkg/abstract"
@@ -21,10 +22,16 @@ const (
 	// The index into partition UUIDs by name
 	_PARTITIONS_BY_NAME_KEY = "partitions/by-name/%s"
 	// The index into Partition protobuffer objects by UUID
-	// $PARTITION refers to the key namespace at
-	// $ROOT/partitions/by-uuid/{partition_uuid}
 	_PARTITIONS_BY_UUID_KEY = "partitions/by-uuid/%s"
 )
+
+// kvPartition returns an etcd.KV that is nahespaced to a specific partition.
+// We use the nomenclature $PARTITION to refer to this key namespace.
+// $PARTITION refers to $ROOT/partitions/by-uuid/{partition_uuid}/
+func (s *Store) kvPartition(partition string) etcd.KV {
+	key := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partition) + "/"
+	return etcd_namespace.NewKV(s.kv, key)
+}
 
 // PartitionGet returns a Partition protobuffer message that has the UUID or
 // name of the supplied search string

--- a/pkg/metadata/storage/partition.go
+++ b/pkg/metadata/storage/partition.go
@@ -1,8 +1,6 @@
 package storage
 
 import (
-	"fmt"
-
 	etcd "github.com/coreos/etcd/clientv3"
 	etcd_namespace "github.com/coreos/etcd/clientv3/namespace"
 	"github.com/gogo/protobuf/proto"
@@ -20,16 +18,16 @@ const (
 	// listed by UUID with values containing Partition protobuffer records.
 	_PARTITIONS_KEY = "partitions/"
 	// The index into partition UUIDs by name
-	_PARTITIONS_BY_NAME_KEY = "partitions/by-name/%s"
+	_PARTITIONS_BY_NAME_KEY = "partitions/by-name/"
 	// The index into Partition protobuffer objects by UUID
-	_PARTITIONS_BY_UUID_KEY = "partitions/by-uuid/%s"
+	_PARTITIONS_BY_UUID_KEY = "partitions/by-uuid/"
 )
 
 // kvPartition returns an etcd.KV that is nahespaced to a specific partition.
 // We use the nomenclature $PARTITION to refer to this key namespace.
 // $PARTITION refers to $ROOT/partitions/by-uuid/{partition_uuid}/
-func (s *Store) kvPartition(partition string) etcd.KV {
-	key := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partition) + "/"
+func (s *Store) kvPartition(partUuid string) etcd.KV {
+	key := _PARTITIONS_BY_UUID_KEY + partUuid + "/"
 	return etcd_namespace.NewKV(s.kv, key)
 }
 
@@ -47,7 +45,7 @@ func (s *Store) PartitionGet(
 
 	// First try looking up the partition by UUID. If not, match, then we try
 	// the by-name index...
-	byUuidKey := fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, search)
+	byUuidKey := _PARTITIONS_BY_UUID_KEY + search
 	grByUuid, err := s.kv.Get(ctx, byUuidKey)
 	if err != nil {
 		s.log.ERR("error getting key %s: %v", byUuidKey, err)
@@ -55,7 +53,7 @@ func (s *Store) PartitionGet(
 	}
 
 	if grByUuid.Count == 0 {
-		byNameKey := fmt.Sprintf(_PARTITIONS_BY_NAME_KEY, search)
+		byNameKey := _PARTITIONS_BY_NAME_KEY + search
 		grByName, err := s.kv.Get(ctx, byNameKey)
 		if err != nil {
 			s.log.ERR("error getting key %s: %v", byNameKey, err)
@@ -65,7 +63,7 @@ func (s *Store) PartitionGet(
 			return nil, errors.ErrNotFound
 		}
 		partUuid := grByName.Kvs[0].Value
-		byUuidKey = fmt.Sprintf(_PARTITIONS_BY_UUID_KEY, partUuid)
+		byUuidKey = _PARTITIONS_BY_UUID_KEY + string(partUuid)
 		grByUuid, err = s.kv.Get(ctx, byUuidKey)
 		if err != nil {
 			s.log.ERR("error getting key %s: %v", byUuidKey, err)
@@ -94,15 +92,23 @@ func (s *Store) PartitionList(
 ) (abstract.Cursor, error) {
 	ctx, cancel := s.requestCtx()
 	defer cancel()
-
 	resp, err := s.kv.Get(
 		ctx,
-		_PARTITIONS_KEY,
+		_PARTITIONS_BY_UUID_KEY,
 		etcd.WithPrefix(),
+		// Since each partition will have a key namespace equal to
+		// (_PARTITIONS_BY_UUID_KEY + {UUID} + "/") we need to limit our search
+		// range to end with only the fixed 32 characters that all UUID values
+		// comprise. This allows $ROOT/partitions/by-uuid/{UUID} to be returned
+		// but prevents $ROOT/partitions/by-uuid/{UUID}/ from being returned.
+		// The latter is the partition key namespace. The former is the
+		// partition key that contains a serialized Protobuffer object.
+		etcd.WithRange(_PARTITIONS_BY_UUID_KEY+_MAX_UUID),
 		// TODO(jaypipes): Factor the sorting/limiting/pagination out into a
 		// separate utility
 		etcd.WithSort(etcd.SortByKey, etcd.SortAscend),
 	)
+
 	if err != nil {
 		s.log.ERR("error listing partitions: %v", err)
 		return nil, err

--- a/pkg/metadata/storage/store.go
+++ b/pkg/metadata/storage/store.go
@@ -18,6 +18,9 @@ const (
 
 	// Used when creating empty leaf-level keys or key namespaces
 	_NO_VALUE = ""
+
+	// Used in ranges when limiting searches on UUID indexes
+	_MAX_UUID = "ffffffffffffffffffffffffffffffff"
 )
 
 type Store struct {

--- a/pkg/metadata/storage/store.go
+++ b/pkg/metadata/storage/store.go
@@ -14,7 +14,7 @@ const (
 	// The key that carves out a namespace for the runm-metadata service to
 	// store stuff in etcd. This namespace comes directly UNDER the
 	// Config.EtcdKeyPrefix namespace. This namespace is referred to as $ROOT
-	_SERVICE_KEY = "runm-metadata/"
+	_SERVICE_KEY = "runm/metadata/"
 
 	// Used when creating empty leaf-level keys or key namespaces
 	_NO_VALUE = ""
@@ -38,9 +38,7 @@ func New(log *logging.Logs, cfg *config.Config) (*Store, error) {
 		client: client,
 		kv:     etcd_namespace.NewKV(client.KV, cfg.EtcdKeyPrefix+_SERVICE_KEY),
 	}
-	ctx, cancel := s.requestCtx()
-	defer cancel()
-	if err = s.init(ctx); err != nil {
+	if err = s.ensureBootstrap(); err != nil {
 		return nil, err
 	}
 	return s, nil


### PR DESCRIPTION
This fixes Issue #33 and addresses a problem whereby the wrong key was being used to list partitions. We were using `$ROOT/partitions` instead of `$ROOT/partitions/by-uuid/`.

Also cleans up the documentation on how the etcd keys are laid out for the `runm-metadata` service.

Partitions are now able to be listed and fetched using the `runm` client:

```
[jaypipes@uberbox runmachine]$ ./scripts/dump-etcd.sh 
gsr/services/runmachine-metadata/172.17.0.3:10000
runm-test-metadata/runm/metadata/bootstrap
runm-test-metadata/runm/metadata/partitions/by-name/part0
runm-test-metadata/runm/metadata/partitions/by-uuid/e2987a1519064939948df6b7a84b579c
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh partition list
+----------------------------------+-------+
|               UUID               | NAME  |
+----------------------------------+-------+
| e2987a1519064939948df6b7a84b579c | part0 |
+----------------------------------+-------+
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh partition get part0
UUID: e2987a1519064939948df6b7a84b579c
Name: part0
```