### PR TITLE
Property schema fixes

### DIFF
--- a/cmd/runm/commands/common.go
+++ b/cmd/runm/commands/common.go
@@ -93,11 +93,9 @@ func getSession() *pb.Session {
 		// able to find missing user/project/partition information
 	}
 	return &pb.Session{
-		User:    user,
-		Project: project,
-		Partition: &pb.Partition{
-			Uuid: partition,
-		},
+		User:      user,
+		Project:   project,
+		Partition: partition,
 	}
 }
 

--- a/cmd/runm/commands/property_schema_get.go
+++ b/cmd/runm/commands/property_schema_get.go
@@ -41,14 +41,10 @@ func propertySchemaGet(cmd *cobra.Command, args []string) {
 	client := pb.NewRunmMetadataClient(conn)
 
 	session := getSession()
-	partition := session.Partition.Uuid
-	if propSchemaGetPartition != "" {
-		partition = propSchemaGetPartition
-	}
 
 	req := &pb.PropertySchemaGetRequest{
 		Session:    session,
-		Partition:  partition,
+		Partition:  propSchemaGetPartition,
 		ObjectType: args[0],
 		Key:        args[1],
 	}

--- a/cmd/runm/commands/property_schema_list.go
+++ b/cmd/runm/commands/property_schema_list.go
@@ -18,14 +18,12 @@ var propertySchemaListCommand = &cobra.Command{
 }
 
 func propertySchemaList(cmd *cobra.Command, args []string) {
-	filters := &pb.PropertySchemaListFilters{}
 	conn := connect()
 	defer conn.Close()
 
 	client := pb.NewRunmMetadataClient(conn)
 	req := &pb.PropertySchemaListRequest{
 		Session: getSession(),
-		Filters: filters,
 	}
 	stream, err := client.PropertySchemaList(context.Background(), req)
 	exitIfConnectErr(err)

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -223,16 +223,18 @@ message PropertySchemaSetResponse {
     PropertySchema property_schema = 2;
 }
 
-message PropertySchemaListFilters {
-    repeated string partitions = 1;
-    repeated string object_types = 2;
-    repeated string keys = 3;
+message PropertySchemaListFilter {
+    string partition = 1;
+    string object_type = 2;
+    string key = 3;
 }
 
 message PropertySchemaListRequest {
     Session session = 1;
-    PropertySchemaListFilters filters = 2;
-    SearchOptions options = 3;
+    SearchOptions options = 2;
+    // A set of filter expressions that are OR'd together when determining
+    // matches
+    repeated PropertySchemaListFilter any = 3;
 }
 
 message PropertySchemaDeleteRequest {

--- a/proto/defs/session.proto
+++ b/proto/defs/session.proto
@@ -12,9 +12,6 @@ message Session {
     // A project is a tenant/account the user belongs to. It associates a user
     // with billing and quotas.
     string project = 2;
-    // The partition that the user is "targeting". This can be empty, which
-    // indicates that the user is accessing information across multiple
-    // partitions. This partition identifier, when not empty, will be used when
-    // constructing new providers or when listing providers.
-    Partition partition = 3;
+    // The partition that the user is "targeting".
+    string partition = 3;
 }


### PR DESCRIPTION
Changes the Session protobuf message to have a string partition field instead of a Partition object field. This is necessary for the config-file work I've been working on. Secondly, refactors the property list implementation to remove the gRPC PropertySchemaListRequest from the storage layer's PropertySchemaList method signature, replacing it with a slice of non-protobuffer PropertySchemaFilter structs.