### PR TITLE
object type list

### DIFF
--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -69,12 +69,17 @@ for short) in this document.
 
 ### The `$ROOT` key namespace
 
-The keys directly under `$ROOT` describe the known **partitions** in the
-system. It's easier to explain the structure by looking at a sample key
-namespace layout.
+The keys directly under `$ROOT` describe the known **object types** and
+**partitions** in the system. It's easier to explain the structure by looking
+at a sample key namespace layout.
 
 ```
 $ROOT
+  object-types/
+    runm.image -> serialized ObjectType Protobuffer message
+    runm.machine -> serialized ObjectType Protobuffer message
+    runm.provider -> serialized ObjectType Protobuffer message
+    runm.provider_group -> serialized ObjectType Protobuffer message
   partitions/
     by-name/
       us-east.example.com -> d3873f99a21f45f5bce156c1f8b84b03
@@ -84,12 +89,18 @@ $ROOT
       d79706e01fbd4e48aae89209061cdb71
 ```
 
-Above, you can see that `$ROOT` has a single key namespace called `partitions`.
-This key has two key namespaces below it, called `by-name` and `by-uuid`.
+Above, you can see that `$ROOT` has two key namespaces, one called
+`object-types` and another called `partitions`.
 
-The `$ROOT/partitions/by-name/` key namespace contains [valued keys](#Valued
-keys), with the key being the human-readable name of the partition and the
-value being the UUID of that partition.
+The `$ROOT/object-types` key namespace has a set of [valued keys](#Valued keys)
+describing the object types known to the system.
+
+The `$ROOT/partitions/` key namespace has two key namespaces below it, called
+`by-name` and `by-uuid`.
+
+The `$ROOT/partitions/by-name/` key namespace contains valued keys, with the
+key being the human-readable name of the partition and the value being the UUID
+of that partition.
 
 Each UUID value listed in `$ROOT/partitions/by-name/` will be a key namespace
 under `$ROOT/partitions/by-uuid/` that contains *all* objects known to that

--- a/cmd/runm/commands/object_type.go
+++ b/cmd/runm/commands/object_type.go
@@ -1,0 +1,14 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var objectTypeCommand = &cobra.Command{
+	Use:   "object-type",
+	Short: "Fetch object type information",
+}
+
+func init() {
+	objectTypeCommand.AddCommand(objectTypeListCommand)
+}

--- a/cmd/runm/commands/object_type_list.go
+++ b/cmd/runm/commands/object_type_list.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/net/context"
+
+	"github.com/olekukonko/tablewriter"
+	pb "github.com/runmachine-io/runmachine/proto"
+	"github.com/spf13/cobra"
+)
+
+var objectTypeListCommand = &cobra.Command{
+	Use:   "list",
+	Short: "List information about object types",
+	Run:   objectTypeList,
+}
+
+func objectTypeList(cmd *cobra.Command, args []string) {
+	conn := connect()
+	defer conn.Close()
+
+	client := pb.NewRunmMetadataClient(conn)
+	req := &pb.ObjectTypeListRequest{
+		Session: getSession(),
+	}
+	stream, err := client.ObjectTypeList(context.Background(), req)
+	exitIfConnectErr(err)
+
+	msgs := make([]*pb.ObjectType, 0)
+	for {
+		role, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		exitIfError(err)
+		msgs = append(msgs, role)
+	}
+	if len(msgs) == 0 {
+		exitNoRecords()
+	}
+	headers := []string{
+		"Code",
+		"Description",
+	}
+	rows := make([][]string, len(msgs))
+	for x, obj := range msgs {
+		rows[x] = []string{
+			obj.Code,
+			obj.Description,
+		}
+	}
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(headers)
+	table.AppendBulk(rows)
+	table.Render()
+}

--- a/cmd/runm/commands/root.go
+++ b/cmd/runm/commands/root.go
@@ -111,6 +111,7 @@ func init() {
 
 	RootCommand.AddCommand(helpEnvCommand)
 	RootCommand.AddCommand(bootstrapCommand)
+	RootCommand.AddCommand(objectTypeCommand)
 	RootCommand.AddCommand(propertySchemaCommand)
 	RootCommand.AddCommand(partitionCommand)
 	RootCommand.SilenceUsage = true

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,115 @@
+# Concepts in `runmachine`
+
+This documents various objects exposed by `runmachine` and critical concepts
+involved in a `runmachine` deployment.
+
+## Access control
+
+**Access control** is the process of both *authenticating* a user as well as
+*authorizing* that user to perform some action against the system.
+
+`runmachine` does not implement its own authentication functionality. Instead,
+it relies on an external *identity provider* to perform authentication and tell
+`runmachine` what types of actions a *user* is permitted to take against a
+`runmachine` system.
+
+## Identity provider
+
+The *identity provider* determines whether a supplied set of *credentials* is
+allowed to interact with a `runmachine` deployment.
+
+When performing actions against a `runmachine`, the user specifies a set of
+*credentials* that are used to communicate with the identity provider.
+
+## Credentials
+
+Credentials are what are supplied to an identity provider to identify the user
+and determine the scope of authorized actions that user has in the target
+system.
+
+Credentials always include a *partition* and a *project* when communicating
+with an identity provider. The combination of partition and project, along with
+the user, allow the identity provider to determine the scope of authorized
+actions.
+
+## Partitions
+
+A **partition** is `runmachine`'s way of carving up the world into smaller
+manageable divisions. It is comprised of a globally unique identifier (UUID)
+and a human-readable name. A partition may describe a geographic location or an
+entirely abstract division.
+
+When interacting with a `runmachine` deployment, users *MUST* specify the
+partition that they are interacting with. This does *NOT* mean that
+`runmachine` can only execute operations against a single partition at a time.
+Users are authorized to access or execute actions against a specific partition.
+
+## Projects
+
+A **project**, provided by a user when performing actions against a
+`runmachine` deployment, is a *globally-unique identifier* that indicates the
+role or group that the user is acting as.
+
+## Objects
+
+An object is something that has all of the following characteristics:
+
+* It has external human-readable name that is unique within either the scope of
+  a partition or the combination of the partition and project
+* It has a globally-unique identifier (UUID)
+* It can have *properties* associated with it
+* It can have *tags* associated with it
+
+## Object Types
+
+In `runmachine` systems, objects all have a specific **object type**. An object
+type is a well-known code, such as `runm.machine` along with a description of
+what the type of object is used for.
+
+## Properties
+
+TODO
+
+## Tags
+
+TODO
+
+## Property Schemas
+
+TODO
+
+## Machines
+
+TODO
+
+## Images
+
+TODO
+
+## Providers
+
+TODO
+
+## Provider Groups
+
+TODO
+
+## Capabilities
+
+TODO
+
+## Resource Types
+
+TODO
+
+## Inventories
+
+TODO
+
+## Claims
+
+TODO
+
+## Allocations
+
+TODO

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -47,31 +47,3 @@ func (s *Server) ObjectPropertiesSet(
 ) (*pb.ObjectPropertiesSetResponse, error) {
 	return nil, nil
 }
-
-func (s *Server) ObjectTypeDelete(
-	ctx context.Context,
-	req *pb.ObjectTypeDeleteRequest,
-) (*pb.ObjectTypeDeleteResponse, error) {
-	return nil, nil
-}
-
-func (s *Server) ObjectTypeGet(
-	ctx context.Context,
-	req *pb.ObjectTypeGetRequest,
-) (*pb.ObjectType, error) {
-	return nil, nil
-}
-
-func (s *Server) ObjectTypeList(
-	req *pb.ObjectTypeListRequest,
-	stream pb.RunmMetadata_ObjectTypeListServer,
-) error {
-	return nil
-}
-
-func (s *Server) ObjectTypeSet(
-	ctx context.Context,
-	req *pb.ObjectTypeSetRequest,
-) (*pb.ObjectTypeSetResponse, error) {
-	return nil, nil
-}

--- a/pkg/metadata/object_type.go
+++ b/pkg/metadata/object_type.go
@@ -1,0 +1,36 @@
+package metadata
+
+import (
+	"context"
+
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+func (s *Server) ObjectTypeGet(
+	ctx context.Context,
+	req *pb.ObjectTypeGetRequest,
+) (*pb.ObjectType, error) {
+	return nil, nil
+}
+
+func (s *Server) ObjectTypeList(
+	req *pb.ObjectTypeListRequest,
+	stream pb.RunmMetadata_ObjectTypeListServer,
+) error {
+	cur, err := s.store.ObjectTypeList(req.Any)
+	if err != nil {
+		return err
+	}
+	defer cur.Close()
+	var key string
+	var msg pb.ObjectType
+	for cur.Next() {
+		if err = cur.Scan(&key, &msg); err != nil {
+			return err
+		}
+		if err = stream.Send(&msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/metadata/storage/object_type.go
+++ b/pkg/metadata/storage/object_type.go
@@ -1,0 +1,57 @@
+package storage
+
+import (
+	etcd "github.com/coreos/etcd/clientv3"
+
+	"github.com/runmachine-io/runmachine/pkg/abstract"
+	"github.com/runmachine-io/runmachine/pkg/cursor"
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+const (
+	_OBJECT_TYPES_KEY = "object-types/"
+)
+
+// ObjectTypeList returns a cursor over zero or more ObjectType
+// protobuffer objects matching a set of supplied filters.
+func (s *Store) ObjectTypeList(
+	any []*pb.ObjectTypeFilter,
+) (abstract.Cursor, error) {
+	if len(any) == 0 {
+		// Just return all object types
+		return s.objectTypesGetByCode("", true)
+	}
+	for _, filter := range any {
+		// TODO(jaypipes): Merge all returned getters into a single cursor
+		return s.objectTypesGetByCode(filter.Code, filter.UsePrefix)
+	}
+	return nil, nil
+}
+
+func (s *Store) objectTypesGetByCode(
+	code string,
+	usePrefix bool,
+) (abstract.Cursor, error) {
+	ctx, cancel := s.requestCtx()
+	defer cancel()
+
+	key := _OBJECT_TYPES_KEY + code
+
+	opts := []etcd.OpOption{
+		// TODO(jaypipes): Factor the sorting/limiting/pagination out into a
+		// separate utility
+		etcd.WithSort(etcd.SortByKey, etcd.SortAscend),
+	}
+
+	if usePrefix {
+		opts = append(opts, etcd.WithPrefix())
+	}
+
+	resp, err := s.kv.Get(ctx, key, opts...)
+	if err != nil {
+		s.log.ERR("error listing object types: %v", err)
+		return nil, err
+	}
+
+	return cursor.NewEtcdPBCursor(resp), nil
+}

--- a/pkg/metadata/storage/object_type.go
+++ b/pkg/metadata/storage/object_type.go
@@ -2,15 +2,82 @@ package storage
 
 import (
 	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/runmachine-io/runmachine/pkg/abstract"
 	"github.com/runmachine-io/runmachine/pkg/cursor"
+	"github.com/runmachine-io/runmachine/pkg/errors"
 	pb "github.com/runmachine-io/runmachine/proto"
 )
 
 const (
 	_OBJECT_TYPES_KEY = "object-types/"
 )
+
+var (
+	// The collection of well-known runm object types
+	runmObjectTypes = []*pb.ObjectType{
+		&pb.ObjectType{
+			Code:        "runm.partition",
+			Description: "A division of resources. A deployment unit for runm",
+		},
+		&pb.ObjectType{
+			Code:        "runm.image",
+			Description: "A bootable bunch of bits",
+		},
+		&pb.ObjectType{
+			Code:        "runm.provider",
+			Description: "A provider of some resources, e.g. a compute node or an SR-IOV NIC",
+		},
+		&pb.ObjectType{
+			Code:        "runm.provider_group",
+			Description: "A group of providers",
+		},
+		&pb.ObjectType{
+			Code:        "runm.machine",
+			Description: "Created by a user, a machine consumes compute resources from one of more providers",
+		},
+	}
+)
+
+// ensureObjectTypes is responsible for making sure etcd has the well-known
+// runm object types in storage.
+func (s *Store) ensureObjectTypes() error {
+	ctx, cancel := s.requestCtx()
+	defer cancel()
+
+	s.log.L3("ensuring well-known object types...")
+
+	resp, err := s.kv.Get(
+		ctx,
+		_OBJECT_TYPES_KEY,
+		etcd.WithPrefix(),
+		etcd.WithKeysOnly(),
+	)
+	if err != nil {
+		s.log.ERR("error listing object types: %v", err)
+		return err
+	}
+	all := make(map[string]bool, 0)
+	for _, k := range resp.Kvs {
+		all[string(k.Key)] = true
+	}
+
+	for _, ot := range runmObjectTypes {
+		if _, ok := all[ot.Code]; !ok {
+			s.log.L3("object type %s not in storage. adding...", ot.Code)
+			if err = s.objectTypeCreate(ot); err != nil {
+				if err == errors.ErrGenerationConflict {
+					// some other thread created the object type... just ignore
+					continue
+				}
+				return err
+			}
+			s.log.L2("created object type %s", ot.Code)
+		}
+	}
+	return nil
+}
 
 // ObjectTypeList returns a cursor over zero or more ObjectType
 // protobuffer objects matching a set of supplied filters.
@@ -54,4 +121,34 @@ func (s *Store) objectTypesGetByCode(
 	}
 
 	return cursor.NewEtcdPBCursor(resp), nil
+}
+
+// ObjectTypeCreate writes the supplied ObjectType object to the key at
+// $ROOT/object-types/{object_type_code}
+func (s *Store) objectTypeCreate(
+	obj *pb.ObjectType,
+) error {
+	ctx, cancel := s.requestCtx()
+	defer cancel()
+
+	key := _OBJECT_TYPES_KEY + obj.Code
+	value, err := proto.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	// create the object type using a transaction that ensures another thread
+	// hasn't created an object type with the same key underneath us
+	onSuccess := etcd.OpPut(key, string(value))
+	// Ensure the key doesn't yet exist
+	compare := etcd.Compare(etcd.Version(key), "=", 0)
+	resp, err := s.kv.Txn(ctx).If(compare).Then(onSuccess).Commit()
+
+	if err != nil {
+		s.log.ERR("failed to create txn in etcd: %v", err)
+		return err
+	} else if resp.Succeeded == false {
+		s.log.L3("another thread already created key %s", key)
+		return errors.ErrGenerationConflict
+	}
+	return nil
 }

--- a/pkg/metadata/storage/store.go
+++ b/pkg/metadata/storage/store.go
@@ -44,6 +44,9 @@ func New(log *logging.Logs, cfg *config.Config) (*Store, error) {
 	if err = s.ensureBootstrap(); err != nil {
 		return nil, err
 	}
+	if err = s.ensureObjectTypes(); err != nil {
+		return nil, err
+	}
 	return s, nil
 }
 

--- a/proto/defs/object_type.proto
+++ b/proto/defs/object_type.proto
@@ -2,11 +2,9 @@ syntax = "proto3";
 
 package runm;
 
-import "wrappers.proto";
-
 // An object type is a simple classification for various types of things known
 // to the runm system
 message ObjectType {
     string code = 1;
-    StringValue description = 2;
+    string description = 2;
 }

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -33,14 +33,6 @@ service RunmMetadata {
     // Returns information about a specific object type
     rpc object_type_get(ObjectTypeGetRequest) returns (ObjectType) {}
 
-    // Deletes one or more object typees
-    rpc object_type_delete(ObjectTypeDeleteRequest) returns (
-        ObjectTypeDeleteResponse) {}
-
-    // Set information about a specific object type
-    rpc object_type_set(ObjectTypeSetRequest) returns (
-        ObjectTypeSetResponse) {}
-
     // Returns information about multiple object types
     rpc object_type_list(ObjectTypeListRequest) returns (
         stream ObjectType) {}
@@ -121,43 +113,23 @@ message PartitionListRequest {
 
 message ObjectTypeGetRequest {
     Session session = 1;
-    string search = 2;
+    // An exact-match search term on the object type's string code
+    string code = 2;
 }
 
-message ObjectTypeSetFields {
-    StringValue code = 1;
-    StringValue description = 2;
-}
-
-message ObjectTypeSetRequest {
-    Session session = 1;
-    ObjectType object_type = 2;
-    ObjectTypeSetFields changed = 3;
-}
-
-message ObjectTypeSetResponse {
-    repeated Error errors = 1;
-    ObjectType object_type = 2;
-}
-
-message ObjectTypeListFilters {
-    repeated string identifiers = 1;
+message ObjectTypeFilter {
+    // A search term on the object type's string code
+    string code = 1;
+    // Indicates the search should be a prefix expression
+    bool use_prefix = 2;
 }
 
 message ObjectTypeListRequest {
     Session session = 1;
-    ObjectTypeListFilters filters = 2;
-    SearchOptions options = 3;
-}
-
-message ObjectTypeDeleteRequest {
-    Session session = 1;
-    repeated ObjectType object_types = 2;
-}
-
-message ObjectTypeDeleteResponse {
-    repeated Error errors = 1;
-    uint64 num_deleted = 2;
+    SearchOptions options = 2;
+    // A set of filter expressions that are OR'd together when determining
+    // matches
+    repeated ObjectTypeFilter any = 3;
 }
 
 message ObjectGetRequest {


### PR DESCRIPTION
Implements server and client side of ObjectTypeList gRPC API method for
listing information about object types.

Ensures all well-known runm object types exist in backend storage when
storage is initialized. If storage layer doesn't find each well-known
object type, creates it:

```
[jaypipes@uberbox runmachine]$ docker logs runm-test-metadata
2018/11/18 15:36:39 [runm-metadata] connecting to gsr service registry.
2018/11/18 15:36:39 [gsr] connecting to etcd endpoints [http://172.17.0.2:2379] (w/ 5m0s overall timeout).
2018/11/18 15:36:39 [gsr] connected to registry.
2018/11/18 15:36:39 [gsr] creating watch on gsr/services/
2018/11/18 15:36:39 [runm-metadata] connected to gsr service registry.
2018/11/18 15:36:39 [runm-metadata] connecting to etcd endpoints [http://172.17.0.2:2379] (w/ 5m0s overall timeout).
2018/11/18 15:36:39 [runm-metadata] ensuring bootstrap token...
2018/11/18 15:36:39 [runm-metadata] bootstrap token created
2018/11/18 15:36:39 [runm-metadata] ensuring well-known object types...
2018/11/18 15:36:39 [runm-metadata] object type runm.partition not in storage. adding...
2018/11/18 15:36:39 [runm-metadata] created object type runm.partition
2018/11/18 15:36:39 [runm-metadata] object type runm.image not in storage. adding...
2018/11/18 15:36:39 [runm-metadata] created object type runm.image
2018/11/18 15:36:39 [runm-metadata] object type runm.provider not in storage. adding...
2018/11/18 15:36:39 [runm-metadata] created object type runm.provider
2018/11/18 15:36:39 [runm-metadata] object type runm.provider_group not in storage. adding...
2018/11/18 15:36:39 [runm-metadata] created object type runm.provider_group
2018/11/18 15:36:39 [runm-metadata] object type runm.machine not in storage. adding...
2018/11/18 15:36:39 [runm-metadata] created object type runm.machine
2018/11/18 15:36:39 [runm-metadata] connected to metadata storage.
2018/11/18 15:36:39 [gsr] read 0 endpoints @ generation 47
2018/11/18 15:36:39 [gsr] creating new registry entry for runmachine-metadata:172.17.0.3:10000
2018/11/18 15:36:39 [gsr] started heartbeat channel
2018/11/18 15:36:39 [gsr] received notification that runmachine-metadata:172.17.0.3:10000 was created.
2018/11/18 15:36:39 [runm-metadata] registered runmachine-metadata service endpoint running at 172.17.0.3:10000 with gsr.
2018/11/18 15:36:39 [runm-metadata] listening on TCP 172.17.0.3:10000
```

and object types are now shows in `runm object-type list`:

```
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh object-type list
+---------------------+--------------------------------+
|        CODE         |          DESCRIPTION           |
+---------------------+--------------------------------+
| runm.image          | A bootable bunch of bits       |
| runm.machine        | Created by a user, a machine   |
|                     | consumes compute resources     |
|                     | from one of more providers     |
| runm.partition      | A division of resources. A     |
|                     | deployment unit for runm       |
| runm.provider       | A provider of some resources,  |
|                     | e.g. a compute node or an      |
|                     | SR-IOV NIC                     |
| runm.provider_group | A group of providers           |
+---------------------+--------------------------------+
```

with the etcd data store showing appropriate keys:

```
[jaypipes@uberbox runmachine]$ ./scripts/dump-etcd.sh | grep object-types
runm-test-metadata/runm/metadata/object-types/runm.image
runm-test-metadata/runm/metadata/object-types/runm.machine
runm-test-metadata/runm/metadata/object-types/runm.partition
runm-test-metadata/runm/metadata/object-types/runm.provider
runm-test-metadata/runm/metadata/object-types/runm.provider_group
```

Issue #37
Issue #39