### PR TITLE
finalize object types APIs

### DIFF
--- a/cmd/runm/commands/object_type.go
+++ b/cmd/runm/commands/object_type.go
@@ -11,4 +11,5 @@ var objectTypeCommand = &cobra.Command{
 
 func init() {
 	objectTypeCommand.AddCommand(objectTypeListCommand)
+	objectTypeCommand.AddCommand(objectTypeGetCommand)
 }

--- a/cmd/runm/commands/object_type_get.go
+++ b/cmd/runm/commands/object_type_get.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	pb "github.com/runmachine-io/runmachine/proto"
+	"github.com/spf13/cobra"
+)
+
+var objectTypeGetCommand = &cobra.Command{
+	Use:   "get <code>",
+	Short: "Show information for a single object type",
+	Args:  cobra.ExactArgs(1),
+	Run:   objectTypeGet,
+}
+
+func objectTypeGet(cmd *cobra.Command, args []string) {
+	conn := connect()
+	defer conn.Close()
+
+	client := pb.NewRunmMetadataClient(conn)
+
+	session := getSession()
+
+	req := &pb.ObjectTypeGetRequest{
+		Session: session,
+		Code:    args[0],
+	}
+	obj, err := client.ObjectTypeGet(context.Background(), req)
+	exitIfError(err)
+	fmt.Printf("Code:        %s\n", obj.Code)
+	fmt.Printf("Description: %s\n", obj.Description)
+}

--- a/pkg/metadata/object_type.go
+++ b/pkg/metadata/object_type.go
@@ -3,14 +3,42 @@ package metadata
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/runmachine-io/runmachine/pkg/errors"
 	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+var (
+	ErrCodeRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"A code to search for is required.",
+	)
 )
 
 func (s *Server) ObjectTypeGet(
 	ctx context.Context,
 	req *pb.ObjectTypeGetRequest,
 ) (*pb.ObjectType, error) {
-	return nil, nil
+	if req.Code == "" {
+		return nil, ErrCodeRequired
+	}
+	obj, err := s.store.ObjectTypeGet(req.Code)
+	if err != nil {
+		if err == errors.ErrNotFound {
+			return nil, ErrNotFound
+		}
+		// We don't want to expose internal errors to the user, so just return
+		// an unknown error after logging it.
+		s.log.ERR(
+			"failed to retrieve object type of %s: %s",
+			req.Code,
+			err,
+		)
+		return nil, ErrUnknown
+	}
+	return obj, nil
 }
 
 func (s *Server) ObjectTypeList(


### PR DESCRIPTION
Completes the remaining work on the object types API:

* Adds support for filtering (with and without prefix support) to the `runm object-type list` command
* Adds a new `runm object-type get <code>` command

Issue #38 
Issue #37