### PR TITLE
initial work on server side of object list operations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,6 +22,12 @@
   version = "v3.3.10"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -86,6 +92,12 @@
   revision = "be2c049b30ccd4d3fd795d6bf7dce74e42eeedaa"
 
 [[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
@@ -96,6 +108,23 @@
   packages = ["."]
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
+
+[[projects]]
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
+  version = "v0.1.1"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = [
+    ".",
+    "assert",
+    "http",
+    "mock"
+  ]
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   name = "go.etcd.io/etcd"
@@ -187,6 +216,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8a12565a8c64b42c9dc6dd975b69108d26ae370021553b514503a91fc05f1af1"
+  inputs-digest = "58e3925aad19551b6fbcb2ed8739d28f2c9d202861eafddc683f69b7f56c1cef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,3 +72,7 @@
 [[constraint]]
   name = "github.com/google/uuid"
   version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.2.2"

--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -80,20 +80,37 @@ $ROOT
     runm.machine -> serialized ObjectType Protobuffer message
     runm.provider -> serialized ObjectType Protobuffer message
     runm.provider_group -> serialized ObjectType Protobuffer message
+  objects/
+    by-uuid/
+      54b8d8d7e24c43799bbf70c16e921e52 -> serialized Object protobuffer message
+      60b53edd16764f6abc081ddb0a73e69c -> serialized Object protobuffer message
+      3bf3e700f11b4a7cb99244c554b3a856 -> serialized Object protobuffer message
   partitions/
     by-name/
       us-east.example.com -> d3873f99a21f45f5bce156c1f8b84b03
       us-west.example.com -> d79706e01fbd4e48aae89209061cdb71
     by-uuid/
-      d3873f99a21f45f5bce156c1f8b84b03
-      d79706e01fbd4e48aae89209061cdb71
+      d3873f99a21f45f5bce156c1f8b84b03 -> serialized Partition protobuffer message
+      d79706e01fbd4e48aae89209061cdb71 -> serialized Partition protobuffer message
 ```
 
-Above, you can see that `$ROOT` has two key namespaces, one called
-`object-types` and another called `partitions`.
+Above, you can see that `$ROOT` has three key namespaces, one called
+`object-types/`, one called `objects/by-uuid/` and another called `partitions/`.
 
-The `$ROOT/object-types` key namespace has a set of [valued keys](#Valued keys)
+The `$ROOT/object-types/` key namespace has a set of [valued keys](#Valued keys)
 describing the object types known to the system.
+
+The `$ROOT/objects/by-uuid/` key namespace has a set of valued keys describing
+the objects known to the system.
+
+The valued keys in the `$ROOT/objects/by-uuid/` key namespace have the UUID of
+the object as the key and a serialized Google Protobuffer message of the
+[Object](../../../proto/defs/object.proto) itself as the value.
+
+**NOTE**: Having the serialized Object protobuffer message as the value of the
+`$ROOT/objects/by-uuid/` key namespace's valued keys allows the `runm-metadata`
+service to answer queries like "get me the tags on this object" with an
+efficient single key fetch operation.
 
 The `$ROOT/partitions/` key namespace has two key namespaces below it, called
 `by-name` and `by-uuid`.
@@ -151,8 +168,8 @@ in detail in the following sections.
 ### The `$OBJECTS` key namespace
 
 Let's first take a look at what is contained in the `$OBJECTS` key
-namespace. Similar to the `$ROOT/partitions/` key namespace, the `$OBJECTS` key
-namespace contains two key namespaces called `by-type` and `by-uuid`:
+namespace. The `$OBJECTS` key namespace contains a sub key namespaces called
+`by-type` that contains indexes into objects by type.
 
 ```
 $OBJECTS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/objects/)
@@ -168,10 +185,6 @@ $OBJECTS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/objects
         eff883565999408dbec3eb5070d5ecf5/
           by-name/
             instance0-appgroupA -> 3bf3e700f11b4a7cb99244c554b3a856
-  by-uuid/
-    54b8d8d7e24c43799bbf70c16e921e52 -> serialized Object protobuffer message
-    60b53edd16764f6abc081ddb0a73e69c -> serialized Object protobuffer message
-    3bf3e700f11b4a7cb99244c554b3a856 -> serialized Object protobuffer message
 ```
 
 As you see above, the `$OBJECTS/by-type/` key namespace contains additional key
@@ -183,15 +196,6 @@ The example key layout above shows a partition that has two image objects named
 `rhel7.5.2` and `debian-sid` in a project with the UUID
 `eff883565999408dbec3eb5070d5ecf5`. There is also a machine object named
 `instance0-appgroupA` with the UUID of `3bf3e700f11b4a7cb99244c554b3a856`.
-
-The valued keys in the `$OBJECTS/by-uuid/` key namespace have the UUID of the
-object as the key and a serialized Google Protobuffer message of the
-[Object](../../../proto/defs/object.proto) itself as the value.
-
-**NOTE**: Having the serialized Object protobuffer message as the value of the
-`%OBJECTS/by-uuid/` key namespace's valued keys allows the `runm-metadata`
-service to answer queries like "get me the tags on this object" with an
-efficient single key fetch operation.
 
 ### The `$PROPERTY_SCHEMAS` key namespace
 

--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -180,22 +180,25 @@ $OBJECTS (e.g. $ROOT/partitions/by-uuid/d79706e01fbd4e48aae89209061cdb71/objects
           by-name/
             rhel7.5.2 -> 54b8d8d7e24c43799bbf70c16e921e52
             debian-sid -> 60b53edd16764f6abc081ddb0a73e69c
-    runm.machine/
-      by-project/
-        eff883565999408dbec3eb5070d5ecf5/
-          by-name/
-            instance0-appgroupA -> 3bf3e700f11b4a7cb99244c554b3a856
+    runm.provider_group/
+      by-name/
+        us-east1-row1-rack2 -> 3bf3e700f11b4a7cb99244c554b3a856
 ```
 
 As you see above, the `$OBJECTS/by-type/` key namespace contains additional key
 namespaces, arranged in an a series of indexes so that `runm-metadata` can look
-up UUIDs of various objects of that type that belong to a project and have a
-particular name.
+up UUIDs of various objects of that type that have a particular name and
+optionally belong to a specific project.
 
 The example key layout above shows a partition that has two image objects named
 `rhel7.5.2` and `debian-sid` in a project with the UUID
-`eff883565999408dbec3eb5070d5ecf5`. There is also a machine object named
-`instance0-appgroupA` with the UUID of `3bf3e700f11b4a7cb99244c554b3a856`.
+`eff883565999408dbec3eb5070d5ecf5`. There is also a `runm.provider_group` object named
+`us-east1-row1-rack2` with the UUID of `3bf3e700f11b4a7cb99244c554b3a856`.
+Provider groups are objects with an object type scope of `PARTITION` which
+means that these objects are not specific to a project, and therefore the
+`$OBJECTS/by-type/runm.provider_group/by-name` is the only index key namespace
+for these types of objects (there is no `by-project/` sub key namespace under
+the object type).
 
 ### The `$PROPERTY_SCHEMAS` key namespace
 

--- a/cmd/runm/commands/object_type_get.go
+++ b/cmd/runm/commands/object_type_get.go
@@ -34,5 +34,6 @@ func objectTypeGet(cmd *cobra.Command, args []string) {
 	obj, err := client.ObjectTypeGet(context.Background(), req)
 	exitIfError(err)
 	fmt.Printf("Code:        %s\n", obj.Code)
+	fmt.Printf("Scope:       %s\n", obj.Scope.String())
 	fmt.Printf("Description: %s\n", obj.Description)
 }

--- a/cmd/runm/commands/object_type_get.go
+++ b/cmd/runm/commands/object_type_get.go
@@ -26,7 +26,10 @@ func objectTypeGet(cmd *cobra.Command, args []string) {
 
 	req := &pb.ObjectTypeGetRequest{
 		Session: session,
-		Code:    args[0],
+		Filter: &pb.ObjectTypeFilter{
+			Search:    args[0],
+			UsePrefix: false,
+		},
 	}
 	obj, err := client.ObjectTypeGet(context.Background(), req)
 	exitIfError(err)

--- a/cmd/runm/commands/object_type_list.go
+++ b/cmd/runm/commands/object_type_list.go
@@ -56,7 +56,7 @@ func buildObjectTypeFilters() []*pb.ObjectTypeFilter {
 		filters = append(
 			filters,
 			&pb.ObjectTypeFilter{
-				Code:      f,
+				Search:    f,
 				UsePrefix: usePrefix,
 			},
 		)

--- a/cmd/runm/commands/object_type_list.go
+++ b/cmd/runm/commands/object_type_list.go
@@ -90,12 +90,14 @@ func objectTypeList(cmd *cobra.Command, args []string) {
 	}
 	headers := []string{
 		"Code",
+		"Scope",
 		"Description",
 	}
 	rows := make([][]string, len(msgs))
 	for x, obj := range msgs {
 		rows[x] = []string{
 			obj.Code,
+			obj.Scope.String(),
 			obj.Description,
 		}
 	}

--- a/cmd/runm/commands/partition_get.go
+++ b/cmd/runm/commands/partition_get.go
@@ -26,7 +26,9 @@ func partitionGet(cmd *cobra.Command, args []string) {
 
 	req := &pb.PartitionGetRequest{
 		Session: session,
-		Search:  args[0],
+		Filter: &pb.PartitionFilter{
+			Search: args[0],
+		},
 	}
 	obj, err := client.PartitionGet(context.Background(), req)
 	exitIfError(err)

--- a/cmd/runm/commands/partition_list.go
+++ b/cmd/runm/commands/partition_list.go
@@ -18,14 +18,14 @@ var partitionListCommand = &cobra.Command{
 }
 
 func partitionList(cmd *cobra.Command, args []string) {
-	filters := &pb.PartitionListFilters{}
 	conn := connect()
 	defer conn.Close()
 
 	client := pb.NewRunmMetadataClient(conn)
 	req := &pb.PartitionListRequest{
 		Session: getSession(),
-		Filters: filters,
+		// TODO(jaypipes): Allow filtering on name/UUID of partition (with name
+		// prefix?)
 	}
 	stream, err := client.PartitionList(context.Background(), req)
 	exitIfConnectErr(err)

--- a/pkg/abstract/cursor.go
+++ b/pkg/abstract/cursor.go
@@ -1,10 +1,13 @@
 package abstract
 
-// Generic interface for anything that can iterate over rows. Purposefully made
-// to function like database/sql package's Rows interface.  Useful for test
-// mocking and abstracting a storage layer.
+import "github.com/golang/protobuf/proto"
+
+// Generic interface for anything that can iterate over some list of things and
+// parse a protobuf message. Purposefully made to function like database/sql
+// package's Rows interface.  Useful for test mocking and abstracting a storage
+// layer.
 type Cursor interface {
 	Next() bool
 	Close() error
-	Scan(dest ...interface{}) error
+	Scan(msg proto.Message) error
 }

--- a/pkg/cursor/empty.go
+++ b/pkg/cursor/empty.go
@@ -1,0 +1,26 @@
+package cursor
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// implements abstract Cursor interface for an empty list of things
+type EmptyCursor struct{}
+
+func Empty() *EmptyCursor {
+	return &EmptyCursor{}
+}
+
+func (c *EmptyCursor) Scan(msg proto.Message) error {
+	return fmt.Errorf("attempted to Scan an empty cursor.")
+}
+
+func (c *EmptyCursor) Next() bool {
+	return false
+}
+
+func (c *EmptyCursor) Close() error {
+	return nil
+}

--- a/pkg/cursor/etcd.go
+++ b/pkg/cursor/etcd.go
@@ -1,79 +1,45 @@
 package cursor
 
 import (
-	"errors"
 	"fmt"
 
 	etcd "github.com/coreos/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 )
 
-var errNilPtr = errors.New("destination pointer is nil") // embedded in descriptive error
-
 // implements abstract Cursor interface for an etcd key-value store that is
 // storing protobuffer messages as values.
 // NOTE(jaypipes): It is NOT safe to share these objects between threads. The
 // idxScan member is not protected.
-type EtcdPBCursor struct {
+type EtcdGetResponseCursor struct {
 	resp    *etcd.GetResponse
 	idxScan int64 // The last record that was Scan()'d
 }
 
-func NewEtcdPBCursor(resp *etcd.GetResponse) *EtcdPBCursor {
-	return &EtcdPBCursor{
+func NewFromEtcdGetResponse(resp *etcd.GetResponse) *EtcdGetResponseCursor {
+	return &EtcdGetResponseCursor{
 		resp:    resp,
 		idxScan: 0,
 	}
 }
 
-func (c *EtcdPBCursor) Scan(dest ...interface{}) error {
+func (c *EtcdGetResponseCursor) Scan(msg proto.Message) error {
 	idx := c.idxScan
 	if idx > c.resp.Count {
-		return fmt.Errorf("attempted to read past end of etcd cursor.")
+		return fmt.Errorf("attempted to read past end of etcd get response cursor.")
 	}
-
-	if err := copyToDest(dest[0], c.resp.Kvs[idx].Key); err != nil {
-		return err
-	}
-	if err := proto.Unmarshal(c.resp.Kvs[idx].Value, dest[1].(proto.Message)); err != nil {
+	if err := proto.Unmarshal(c.resp.Kvs[idx].Value, msg); err != nil {
 		return err
 	}
 	c.idxScan += 1
 	return nil
 }
 
-func copyToDest(dest interface{}, src []byte) error {
-	switch d := dest.(type) {
-	case *string:
-		if d == nil {
-			return errNilPtr
-		}
-		*d = string(src)
-		return nil
-	case *[]byte:
-		if d == nil {
-			return errNilPtr
-		}
-		*d = cloneBytes(src)
-		return nil
-	}
-	return fmt.Errorf("unsupported Scan from src type %T into dest type %T", src, dest)
-}
-
-func cloneBytes(b []byte) []byte {
-	if b == nil {
-		return nil
-	}
-	c := make([]byte, len(b))
-	copy(c, b)
-	return c
-}
-
-func (c *EtcdPBCursor) Next() bool {
+func (c *EtcdGetResponseCursor) Next() bool {
 	cnt := c.resp.Count
 	return cnt > 0 && c.idxScan < cnt
 }
 
-func (c *EtcdPBCursor) Close() error {
+func (c *EtcdGetResponseCursor) Close() error {
 	return nil
 }

--- a/pkg/cursor/slice_pb.go
+++ b/pkg/cursor/slice_pb.go
@@ -1,0 +1,43 @@
+package cursor
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// implements abstract Cursor interface for a slice of protobuffer message
+// struct pointers
+// NOTE(jaypipes): It is NOT safe to share these objects between threads. The
+// idxScan member is not protected.
+type SlicePBMessageCursor struct {
+	vals    []proto.Message
+	idxScan int // The last record that was Scan()'d
+}
+
+func NewFromSlicePBMessages(vals []proto.Message) *SlicePBMessageCursor {
+	return &SlicePBMessageCursor{
+		vals:    vals,
+		idxScan: 0,
+	}
+}
+
+func (c *SlicePBMessageCursor) Scan(msg proto.Message) error {
+	idx := c.idxScan
+	if idx > len(c.vals) {
+		return fmt.Errorf("attempted to read past end of slice of protobuffer messages cursor.")
+	}
+
+	proto.Merge(msg, c.vals[c.idxScan])
+	c.idxScan += 1
+	return nil
+}
+
+func (c *SlicePBMessageCursor) Next() bool {
+	cnt := len(c.vals)
+	return cnt > 0 && c.idxScan < cnt
+}
+
+func (c *SlicePBMessageCursor) Close() error {
+	return nil
+}

--- a/pkg/metadata/bootstrap.go
+++ b/pkg/metadata/bootstrap.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	pb "github.com/runmachine-io/runmachine/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/runmachine-io/runmachine/pkg/util"
+	pb "github.com/runmachine-io/runmachine/proto"
 )
 
 var (
@@ -39,7 +41,7 @@ func (s *Server) Bootstrap(
 	} else {
 		partUuid = req.PartitionUuid.Value
 	}
-	partUuid = normalizeUuid(partUuid)
+	partUuid = util.NormalizeUuid(partUuid)
 
 	if err := s.store.Bootstrap(token, partName, partUuid); err != nil {
 		return nil, err

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -3,6 +3,8 @@ package metadata
 import (
 	"context"
 
+	"github.com/runmachine-io/runmachine/pkg/errors"
+	"github.com/runmachine-io/runmachine/pkg/metadata/storage"
 	pb "github.com/runmachine-io/runmachine/proto"
 )
 
@@ -20,10 +22,138 @@ func (s *Server) ObjectGet(
 	return nil, nil
 }
 
+// buildPartitionObjectFilters is used to expand an ObjectFilter, which may
+// contain PartitionFilter and ObjectTypeFilter objects that themselves may
+// resolve to multiple partitions or object types, to a set of
+// PartitionObjectFilter objects. A PartitionObjectFilter is used to describe a
+// filter on objects in a *specific* partition and having a *specific* object
+// type.
+func (s *Server) buildPartitionObjectFilters(
+	filter *pb.ObjectFilter,
+) ([]*storage.PartitionObjectFilter, error) {
+	res := make([]*storage.PartitionObjectFilter, 0)
+	// A set of partition UUIDs that we'll create PartitionObjectFilters with.
+	// These are the UUIDs of any partitions that match the PartitionFilter in
+	// the supplied pb.ObjectFilter
+	partUuids := make(map[string]bool, 0)
+	// A set of object type codes that we'll create PartitionObjectFilters
+	// with. These are the codes of object types that match the
+	// ObjectTypeFilter in the supplied ObjectFilter
+	otCodes := make(map[string]bool, 0)
+
+	if filter.Partition != nil {
+		// Verify that the requested partition(s) exist(s) and for each
+		// requested partition match, construct a new PartitionObjectFilter
+		cur, err := s.store.PartitionList([]*pb.PartitionFilter{filter.Partition})
+		if err != nil {
+			return nil, err
+		}
+		defer cur.Close()
+
+		var part pb.Partition
+		for cur.Next() {
+			if err = cur.Scan(&part); err != nil {
+				return nil, err
+			}
+			partUuids[part.Uuid] = true
+		}
+	}
+	if filter.ObjectType != nil {
+		// Verify that the object type even exists
+		cur, err := s.store.ObjectTypeList([]*pb.ObjectTypeFilter{filter.ObjectType})
+		if err != nil {
+			return nil, err
+		}
+		defer cur.Close()
+
+		var ot pb.ObjectType
+		for cur.Next() {
+			if err = cur.Scan(&ot); err != nil {
+				return nil, err
+			}
+			otCodes[ot.Code] = true
+		}
+	}
+
+	for partUuid := range partUuids {
+		if len(otCodes) == 0 {
+			f := &storage.PartitionObjectFilter{
+				PartitionUuid: partUuid,
+			}
+			res = append(res, f)
+		} else {
+			for otCode := range otCodes {
+				f := &storage.PartitionObjectFilter{
+					PartitionUuid:  partUuid,
+					ObjectTypeCode: otCode,
+				}
+				res = append(res, f)
+			}
+		}
+	}
+
+	// Now that we've expanded our partitions and object types, add in the
+	// original ObjectFilter's Search and UsePrefix for each
+	// PartitionObjectFilter we've created
+	for _, pf := range res {
+		pf.Search = filter.Search
+		pf.UsePrefix = filter.UsePrefix
+	}
+	return res, nil
+}
+
 func (s *Server) ObjectList(
 	req *pb.ObjectListRequest,
 	stream pb.RunmMetadata_ObjectListServer,
 ) error {
+	any := make([]*storage.PartitionObjectFilter, 0)
+	for _, filter := range req.Any {
+		if pfs, err := s.buildPartitionObjectFilters(filter); err != nil {
+			if err == errors.ErrNotFound {
+				// Just continue since clearly we can have no objects matching
+				// an unknown partition but we need to OR together all filters,
+				// which is why we don't just return nil here
+				continue
+			}
+			return ErrUnknown
+		} else if len(pfs) > 0 {
+			for _, pf := range pfs {
+				any = append(any, pf)
+			}
+		}
+	}
+	if len(any) == 0 {
+		// By default, filter by the session's partition
+		part, err := s.store.PartitionGet(req.Session.Partition)
+		if err != nil {
+			if err == errors.ErrNotFound {
+				// Just return nil since clearly we can have no
+				// property schemas matching an unknown partition
+				return nil
+			}
+			return ErrUnknown
+		}
+		any = append(
+			any,
+			&storage.PartitionObjectFilter{
+				PartitionUuid: part.Uuid,
+			},
+		)
+	}
+	cur, err := s.store.ObjectList(any)
+	if err != nil {
+		return err
+	}
+	defer cur.Close()
+	var msg pb.Object
+	for cur.Next() {
+		if err = cur.Scan(&msg); err != nil {
+			return err
+		}
+		if err = stream.Send(&msg); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/metadata/object_type.go
+++ b/pkg/metadata/object_type.go
@@ -21,10 +21,10 @@ func (s *Server) ObjectTypeGet(
 	ctx context.Context,
 	req *pb.ObjectTypeGetRequest,
 ) (*pb.ObjectType, error) {
-	if req.Code == "" {
+	if req.Filter == nil || req.Filter.Search == "" {
 		return nil, ErrCodeRequired
 	}
-	obj, err := s.store.ObjectTypeGet(req.Code)
+	obj, err := s.store.ObjectTypeGet(req.Filter.Search)
 	if err != nil {
 		if err == errors.ErrNotFound {
 			return nil, ErrNotFound
@@ -33,7 +33,7 @@ func (s *Server) ObjectTypeGet(
 		// an unknown error after logging it.
 		s.log.ERR(
 			"failed to retrieve object type of %s: %s",
-			req.Code,
+			req.Filter.Search,
 			err,
 		)
 		return nil, ErrUnknown

--- a/pkg/metadata/object_type.go
+++ b/pkg/metadata/object_type.go
@@ -50,10 +50,9 @@ func (s *Server) ObjectTypeList(
 		return err
 	}
 	defer cur.Close()
-	var key string
 	var msg pb.ObjectType
 	for cur.Next() {
-		if err = cur.Scan(&key, &msg); err != nil {
+		if err = cur.Scan(&msg); err != nil {
 			return err
 		}
 		if err = stream.Send(&msg); err != nil {

--- a/pkg/metadata/partition.go
+++ b/pkg/metadata/partition.go
@@ -49,7 +49,7 @@ func (s *Server) PartitionList(
 	req *pb.PartitionListRequest,
 	stream pb.RunmMetadata_PartitionListServer,
 ) error {
-	cur, err := s.store.PartitionList(req)
+	cur, err := s.store.PartitionList(req.Any)
 	if err != nil {
 		return err
 	}

--- a/pkg/metadata/partition.go
+++ b/pkg/metadata/partition.go
@@ -23,10 +23,10 @@ func (s *Server) PartitionGet(
 	ctx context.Context,
 	req *pb.PartitionGetRequest,
 ) (*pb.Partition, error) {
-	if req.Search == "" {
+	if req.Filter == nil || req.Filter.Search == "" {
 		return nil, ErrSearchRequired
 	}
-	obj, err := s.store.PartitionGet(req.Search)
+	obj, err := s.store.PartitionGet(req.Filter.Search)
 	if err != nil {
 		if err == errors.ErrNotFound {
 			return nil, ErrNotFound
@@ -35,7 +35,7 @@ func (s *Server) PartitionGet(
 		// an unknown error after logging it.
 		s.log.ERR(
 			"failed to retrieve partition with UUID or name of %s: %s",
-			req.Search,
+			req.Filter.Search,
 			err,
 		)
 		return nil, ErrUnknown

--- a/pkg/metadata/partition.go
+++ b/pkg/metadata/partition.go
@@ -54,10 +54,9 @@ func (s *Server) PartitionList(
 		return err
 	}
 	defer cur.Close()
-	var key string
 	var msg pb.Partition
 	for cur.Next() {
-		if err = cur.Scan(&key, &msg); err != nil {
+		if err = cur.Scan(&msg); err != nil {
 			return err
 		}
 		if err = stream.Send(&msg); err != nil {

--- a/pkg/metadata/property.go
+++ b/pkg/metadata/property.go
@@ -158,10 +158,9 @@ func (s *Server) PropertySchemaList(
 		return err
 	}
 	defer cur.Close()
-	var key string
 	var msg pb.PropertySchema
 	for cur.Next() {
-		if err = cur.Scan(&key, &msg); err != nil {
+		if err = cur.Scan(&msg); err != nil {
 			return err
 		}
 		if err = stream.Send(&msg); err != nil {

--- a/pkg/metadata/storage/object.go
+++ b/pkg/metadata/storage/object.go
@@ -1,0 +1,132 @@
+package storage
+
+import (
+	"github.com/golang/protobuf/proto"
+
+	"github.com/runmachine-io/runmachine/pkg/abstract"
+	"github.com/runmachine-io/runmachine/pkg/cursor"
+	"github.com/runmachine-io/runmachine/pkg/errors"
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+const (
+	// $PARTITION/objects/ is a key namespace that has sub key namespaces that
+	// index objects by project+name and by UUID
+	_OBJECTS_KEY = "objects/"
+	// $PARTITION/objects/by-uuid/ is a key namespace that stores valued keys
+	// where the key is the object's UUID and the value is the serialized
+	// Object protobuffer message
+	_OBJECTS_BY_UUID_KEY = "objects/by-uuid/"
+)
+
+type ObjectFilter struct {
+	PartitionUuid  string
+	Project        string
+	ObjectTypeCode string
+	ObjectName     string
+	ObjectUuid     string
+	// TODO(jaypipes): Add support for property and tag filters
+}
+
+// ObjectTypeList returns a cursor over zero or more ObjectType
+// protobuffer objects matching a set of supplied filters.
+func (s *Store) ObjectList(
+	any []*ObjectFilter,
+) (abstract.Cursor, error) {
+	// We iterate over our filters, evaluating each and OR'ing them together
+	// into a set of UUIDs we will look up in the primary
+	// $ROOT/objects/by-uuid/ key namespace index
+	objUuids := make(map[string]bool, 0)
+
+	for _, filter := range any {
+		// If the filter specifies an object UUID, then all we need to do is
+		// grab the object from the primary objects/by-uuid/ index and check
+		// that any other fields in this filter match. If so, add the UUID to
+		// our set and we're good to go.
+		if filter.ObjectUuid != "" {
+			if obj, err := s.objectGetByUuid(filter.ObjectUuid); err != nil {
+				if err == errors.ErrNotFound {
+					continue
+				}
+				return nil, err
+			} else if obj != nil {
+				if filter.PartitionUuid != "" {
+					if obj.PartitionUuid != filter.PartitionUuid {
+						continue
+					}
+				}
+				if filter.Project != "" {
+					if obj.Project != filter.Project {
+						continue
+					}
+				}
+				if filter.ObjectTypeCode != "" {
+					if obj.ObjectTypeCode != filter.ObjectTypeCode {
+						continue
+					}
+				}
+				if filter.ObjectName != "" {
+					if obj.Name != filter.ObjectName {
+						continue
+					}
+				}
+				// Filter match, add it to the object UUID set
+				objUuids[filter.ObjectUuid] = true
+				continue
+			}
+		}
+
+		// OK, the user didn't specify an object UUID in their filter, so we
+		// need to do repeated lookups into the various indexes depending on
+		// what the user filtered by
+
+	}
+	if len(objUuids) == 0 {
+		return nil, nil
+	}
+
+	// Now we have our set of object UUIDs that we will fetch objects from the
+	// primary index. I suppose we could do a single read on a range of UUID
+	// keys and then ignore keys that aren't in our set of object UUIDs. Not
+	// sure what would be faster... probably depend on the length of the key
+	// range resulting from doing a min/max on the object UUID set.
+	objs := make([]proto.Message, len(objUuids))
+	x := 0
+	for objUuid := range objUuids {
+		obj, err := s.objectGetByUuid(objUuid)
+		if err != nil {
+			if err == errors.ErrNotFound {
+				continue
+			}
+			return nil, err
+		}
+		objs[x] = obj
+		x += 1
+	}
+	return cursor.NewFromSlicePBMessages(objs[:x]), nil
+}
+
+func (s *Store) objectGetByUuid(
+	objUuid string,
+) (*pb.Object, error) {
+	ctx, cancel := s.requestCtx()
+	defer cancel()
+
+	key := _OBJECTS_BY_UUID_KEY + objUuid
+
+	resp, err := s.kv.Get(ctx, key)
+	if resp.Count == 0 {
+		return nil, errors.ErrNotFound
+	}
+	if err != nil {
+		s.log.ERR("error getting object by UUID(%s): %v", objUuid, err)
+		return nil, err
+	}
+
+	var obj *pb.Object
+	if err = proto.Unmarshal(resp.Kvs[0].Value, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}

--- a/pkg/metadata/storage/object.go
+++ b/pkg/metadata/storage/object.go
@@ -1,11 +1,13 @@
 package storage
 
 import (
+	etcd "github.com/coreos/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/runmachine-io/runmachine/pkg/abstract"
 	"github.com/runmachine-io/runmachine/pkg/cursor"
 	"github.com/runmachine-io/runmachine/pkg/errors"
+	"github.com/runmachine-io/runmachine/pkg/util"
 	pb "github.com/runmachine-io/runmachine/proto"
 )
 
@@ -19,32 +21,43 @@ const (
 	_OBJECTS_BY_UUID_KEY = "objects/by-uuid/"
 )
 
-type ObjectFilter struct {
+// A specialized filter class that has pre-determined specific partition UUIDs
+// and object type codes. Users pass pb.ObjectFilter messages which contain
+// optional pb.PartitionFilter and pb.ObjectTypeFilter messages. Those may be
+// expanded (due to UsePrefix = true) to a set of partition UUIDs and/or object
+// type codes. We then create zero or more of these PartitionObjectFilter
+// structs that represent a specific filter on partition UUID and object type,
+// along with the the object's name/UUID and UsePrefix flag.
+type PartitionObjectFilter struct {
 	PartitionUuid  string
 	Project        string
 	ObjectTypeCode string
-	ObjectName     string
-	ObjectUuid     string
+	Search         string
+	UsePrefix      bool
 	// TODO(jaypipes): Add support for property and tag filters
 }
 
 // ObjectTypeList returns a cursor over zero or more ObjectType
 // protobuffer objects matching a set of supplied filters.
 func (s *Store) ObjectList(
-	any []*ObjectFilter,
+	any []*PartitionObjectFilter,
 ) (abstract.Cursor, error) {
+	if len(any) == 0 {
+		return s.objectsGetAll()
+	}
 	// We iterate over our filters, evaluating each and OR'ing them together
 	// into a set of UUIDs we will look up in the primary
 	// $ROOT/objects/by-uuid/ key namespace index
-	objUuids := make(map[string]bool, 0)
+	uuids := make(map[string]bool, 0)
 
 	for _, filter := range any {
-		// If the filter specifies an object UUID, then all we need to do is
-		// grab the object from the primary objects/by-uuid/ index and check
-		// that any other fields in this filter match. If so, add the UUID to
-		// our set and we're good to go.
-		if filter.ObjectUuid != "" {
-			if obj, err := s.objectGetByUuid(filter.ObjectUuid); err != nil {
+		// If the filter specifies a Search and it looks like a UUID, then all
+		// we need to do is add the object from the primary objects/by-uuid/
+		// index and check that any other fields in this filter match. If so,
+		// add the UUID to our set and we're good to go.
+		if util.IsUuidLike(filter.Search) {
+			normUuid := util.NormalizeUuid(filter.Search)
+			if obj, err := s.objectGetByUuid(normUuid); err != nil {
 				if err == errors.ErrNotFound {
 					continue
 				}
@@ -65,24 +78,18 @@ func (s *Store) ObjectList(
 						continue
 					}
 				}
-				if filter.ObjectName != "" {
-					if obj.Name != filter.ObjectName {
-						continue
-					}
-				}
 				// Filter match, add it to the object UUID set
-				objUuids[filter.ObjectUuid] = true
+				uuids[normUuid] = true
 				continue
 			}
 		}
 
-		// OK, the user didn't specify an object UUID in their filter, so we
-		// need to do repeated lookups into the various indexes depending on
-		// what the user filtered by
-
+		// TODO(jaypipes): OK, the user didn't specify an object UUID in their
+		// filter, so we need to do repeated lookups into the various indexes
+		// depending on what the user filtered by
 	}
-	if len(objUuids) == 0 {
-		return nil, nil
+	if len(uuids) == 0 {
+		return cursor.Empty(), nil
 	}
 
 	// Now we have our set of object UUIDs that we will fetch objects from the
@@ -90,10 +97,10 @@ func (s *Store) ObjectList(
 	// keys and then ignore keys that aren't in our set of object UUIDs. Not
 	// sure what would be faster... probably depend on the length of the key
 	// range resulting from doing a min/max on the object UUID set.
-	objs := make([]proto.Message, len(objUuids))
+	objs := make([]proto.Message, len(uuids))
 	x := 0
-	for objUuid := range objUuids {
-		obj, err := s.objectGetByUuid(objUuid)
+	for uuid := range uuids {
+		obj, err := s.objectGetByUuid(uuid)
 		if err != nil {
 			if err == errors.ErrNotFound {
 				continue
@@ -106,20 +113,22 @@ func (s *Store) ObjectList(
 	return cursor.NewFromSlicePBMessages(objs[:x]), nil
 }
 
+// objectGetByUuid returns an Object protobuffer message with the supplied
+// object UUID
 func (s *Store) objectGetByUuid(
-	objUuid string,
+	uuid string,
 ) (*pb.Object, error) {
 	ctx, cancel := s.requestCtx()
 	defer cancel()
 
-	key := _OBJECTS_BY_UUID_KEY + objUuid
+	key := _OBJECTS_BY_UUID_KEY + uuid
 
 	resp, err := s.kv.Get(ctx, key)
 	if resp.Count == 0 {
 		return nil, errors.ErrNotFound
 	}
 	if err != nil {
-		s.log.ERR("error getting object by UUID(%s): %v", objUuid, err)
+		s.log.ERR("error getting object by UUID(%s): %v", uuid, err)
 		return nil, err
 	}
 
@@ -129,4 +138,25 @@ func (s *Store) objectGetByUuid(
 	}
 
 	return obj, nil
+}
+
+func (s *Store) objectsGetAll() (abstract.Cursor, error) {
+	ctx, cancel := s.requestCtx()
+	defer cancel()
+
+	resp, err := s.kv.Get(
+		ctx,
+		_OBJECTS_BY_UUID_KEY,
+		etcd.WithPrefix(),
+		// TODO(jaypipes): Factor the sorting/limiting/pagination out into a
+		// separate utility
+		etcd.WithSort(etcd.SortByKey, etcd.SortAscend),
+	)
+
+	if err != nil {
+		s.log.ERR("error listing all objects: %v", err)
+		return nil, err
+	}
+
+	return cursor.NewFromEtcdGetResponse(resp), nil
 }

--- a/pkg/metadata/storage/object_type.go
+++ b/pkg/metadata/storage/object_type.go
@@ -11,6 +11,9 @@ import (
 )
 
 const (
+	// $ROOT/object-types/ is a key namespace containing valued keys where the
+	// key is the object type's code and the value is the serialized ObjectType
+	// protobuffer message
 	_OBJECT_TYPES_KEY = "object-types/"
 )
 

--- a/pkg/metadata/storage/object_type.go
+++ b/pkg/metadata/storage/object_type.go
@@ -120,7 +120,7 @@ func (s *Store) ObjectTypeList(
 	}
 	for _, filter := range any {
 		// TODO(jaypipes): Merge all returned getters into a single cursor
-		return s.objectTypesGetByCode(filter.Code, filter.UsePrefix)
+		return s.objectTypesGetByCode(filter.Search, filter.UsePrefix)
 	}
 	return nil, nil
 }

--- a/pkg/metadata/storage/object_type.go
+++ b/pkg/metadata/storage/object_type.go
@@ -2,7 +2,7 @@ package storage
 
 import (
 	etcd "github.com/coreos/etcd/clientv3"
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 
 	"github.com/runmachine-io/runmachine/pkg/abstract"
 	"github.com/runmachine-io/runmachine/pkg/cursor"

--- a/pkg/metadata/storage/object_type.go
+++ b/pkg/metadata/storage/object_type.go
@@ -147,7 +147,7 @@ func (s *Store) objectTypesGetByCode(
 		return nil, err
 	}
 
-	return cursor.NewEtcdPBCursor(resp), nil
+	return cursor.NewFromEtcdGetResponse(resp), nil
 }
 
 // objectTypeCreate writes the supplied ObjectType object to the key at

--- a/pkg/metadata/storage/object_type.go
+++ b/pkg/metadata/storage/object_type.go
@@ -21,24 +21,24 @@ var (
 	// The collection of well-known runm object types
 	runmObjectTypes = []*pb.ObjectType{
 		&pb.ObjectType{
-			Code:        "runm.partition",
-			Description: "A division of resources. A deployment unit for runm",
-		},
-		&pb.ObjectType{
-			Code:        "runm.image",
-			Description: "A bootable bunch of bits",
-		},
-		&pb.ObjectType{
 			Code:        "runm.provider",
 			Description: "A provider of some resources, e.g. a compute node or an SR-IOV NIC",
+			Scope:       pb.ObjectTypeScope_PARTITION,
 		},
 		&pb.ObjectType{
 			Code:        "runm.provider_group",
 			Description: "A group of providers",
+			Scope:       pb.ObjectTypeScope_PARTITION,
+		},
+		&pb.ObjectType{
+			Code:        "runm.image",
+			Description: "A bootable bunch of bits",
+			Scope:       pb.ObjectTypeScope_PROJECT,
 		},
 		&pb.ObjectType{
 			Code:        "runm.machine",
 			Description: "Created by a user, a machine consumes compute resources from one of more providers",
+			Scope:       pb.ObjectTypeScope_PROJECT,
 		},
 	}
 )

--- a/pkg/metadata/storage/partition.go
+++ b/pkg/metadata/storage/partition.go
@@ -110,7 +110,7 @@ func (s *Store) PartitionList(
 	any []*pb.PartitionFilter,
 ) (abstract.Cursor, error) {
 	if len(any) == 0 {
-		return s.partitionGetAll()
+		return s.partitionsGetAll()
 	}
 
 	// OK, we've got some filters so we need to process each filter, OR'ing
@@ -208,7 +208,7 @@ func (s *Store) partitionUuidsGetByName(
 	return res, nil
 }
 
-func (s *Store) partitionGetAll() (abstract.Cursor, error) {
+func (s *Store) partitionsGetAll() (abstract.Cursor, error) {
 	ctx, cancel := s.requestCtx()
 	defer cancel()
 

--- a/pkg/metadata/storage/partition.go
+++ b/pkg/metadata/storage/partition.go
@@ -114,5 +114,5 @@ func (s *Store) PartitionList(
 		return nil, err
 	}
 
-	return cursor.NewEtcdPBCursor(resp), nil
+	return cursor.NewFromEtcdGetResponse(resp), nil
 }

--- a/pkg/metadata/storage/property.go
+++ b/pkg/metadata/storage/property.go
@@ -107,7 +107,7 @@ func (s *Store) propertySchemaGetFilteredByPartition(
 		return nil, err
 	}
 
-	return cursor.NewEtcdPBCursor(resp), nil
+	return cursor.NewFromEtcdGetResponse(resp), nil
 }
 
 // PropertySchemaCreate writes the supplied PropertySchema object to the key at

--- a/pkg/metadata/util.go
+++ b/pkg/metadata/util.go
@@ -1,9 +1,0 @@
-package metadata
-
-import "strings"
-
-// normalizeUuid simple lowecases and removes all non-alphanumeric characters
-// from the supplied string
-func normalizeUuid(subject string) string {
-	return strings.ToLower(strings.Replace(subject, "-", "", -1))
-}

--- a/pkg/util/uuid.go
+++ b/pkg/util/uuid.go
@@ -1,0 +1,9 @@
+package util
+
+import "strings"
+
+// NormalizeUuid simple lowecases and removes all non-alphanumeric characters
+// from the supplied string
+func NormalizeUuid(subject string) string {
+	return strings.ToLower(strings.Replace(subject, "-", "", -1))
+}

--- a/pkg/util/uuid.go
+++ b/pkg/util/uuid.go
@@ -1,9 +1,31 @@
 package util
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	// Note that we lowercase and remove hyphens before attempting to match
+	// this regex, which is why this is nice and simple
+	regexUuid = regexp.MustCompile("^[0-9a-f]{32}$")
+)
 
 // NormalizeUuid simple lowecases and removes all non-alphanumeric characters
 // from the supplied string
 func NormalizeUuid(subject string) string {
 	return strings.ToLower(strings.Replace(subject, "-", "", -1))
+}
+
+// IsUuidLike return true if the supplied string looks to be a UUID, false
+// otherwise
+func IsUuidLike(subject string) bool {
+	switch len(subject) {
+	case 32:
+		return regexUuid.MatchString(strings.ToLower(subject))
+	case 36:
+		return regexUuid.MatchString(strings.Replace(strings.ToLower(subject), "-", "", -1))
+	default:
+		return false
+	}
 }

--- a/pkg/util/uuid_test.go
+++ b/pkg/util/uuid_test.go
@@ -1,0 +1,87 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/runmachine-io/runmachine/pkg/util"
+)
+
+var (
+	key = "TESTING"
+)
+
+func TestNormalizeUuid(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		val    string
+		expect string
+	}{
+		{
+			val:    "764f59ca-595d-4bb0-b140-00ae16a6ccb8",
+			expect: "764f59ca595d4bb0b14000ae16a6ccb8",
+		},
+		{
+			val:    "764F59CA-595D-4BB0-B140-00AE16A6CCB8",
+			expect: "764f59ca595d4bb0b14000ae16a6ccb8",
+		},
+		{
+			val:    "764F59CA595D4BB0B14000AE16A6CCB8",
+			expect: "764f59ca595d4bb0b14000ae16a6ccb8",
+		},
+		{
+			val:    "764f59ca595d4bb0b14000ae16a6ccb8",
+			expect: "764f59ca595d4bb0b14000ae16a6ccb8",
+		},
+	}
+
+	for _, t := range tests {
+		assert.Equal(t.expect, util.NormalizeUuid(t.val))
+	}
+}
+
+func TestIsUuidLike(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		val    string
+		expect bool
+	}{
+		{
+			val:    "764f59ca-595d-4bb0-b140-00ae16a6ccb8",
+			expect: true,
+		},
+		{
+			val:    "764F59CA-595D-4BB0-B140-00AE16A6CCB8",
+			expect: true,
+		},
+		{
+			val:    "764F59CA595D4BB0B14000AE16A6CCB8",
+			expect: true,
+		},
+		{
+			val:    "764f59ca595d4bb0b14000ae16a6ccb8",
+			expect: true,
+		},
+		{
+			// 36 chars but not a UUID...
+			val:    "764f59ca595d4bb0b14000ae16a6ccb80000",
+			expect: false,
+		},
+		{
+			// 32 chars but not a UUID...
+			val:    "xxxx59ca595d4bb0b14000ae16a6ccb8",
+			expect: false,
+		},
+		{
+			val:    "not a uuid",
+			expect: false,
+		},
+	}
+
+	for _, t := range tests {
+		assert.Equal(t.expect, util.IsUuidLike(t.val))
+	}
+}

--- a/proto/defs/object.proto
+++ b/proto/defs/object.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package runm;
 
+import "object_type.proto";
+import "partition.proto";
 import "property.proto";
 
 // An externally-referenceable object in the runm system. All objects in the
@@ -39,4 +41,17 @@ message Object {
     repeated Property properties = 50;
     // The collection of simple string tags associated with the object
     repeated string tags = 51;
+}
+
+// Used in matching object records
+message ObjectFilter {
+    PartitionFilter partition = 1;
+    ObjectTypeFilter object_type = 2;
+    // The project the object must belong to, if the object type scope of this
+    // object is PROJECT
+    string project = 3;
+    // A search term on the object's UUID or name
+    string search = 4;
+    // Indicates the search should be a prefix expression
+    bool use_prefix = 5;
 }

--- a/proto/defs/object.proto
+++ b/proto/defs/object.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 package runm;
 
 import "property.proto";
-import "object_type.proto";
-import "partition.proto";
 
 // An externally-referenceable object in the runm system. All objects in the
 // system have a type, a partition identifier, an external name and a UUID
@@ -24,9 +22,21 @@ import "partition.proto";
 // responsible for mapping those external names and object types (in this case,
 // the object type would be "runm.provider") to the external UUID identifier.
 message Object {
-    Partition partition = 1;
-    ObjectType object_type = 2;
-    string uuid = 3;
-    string name = 4;
+    // The UUID of the partition this object is in
+    string partition_uuid = 1;
+    // The object type code this object is
+    string object_type_code = 2;
+    // The external identifier of the project this object is owned by. Can be
+    // empty if the type of object isn't ownable by a project (for instance, a
+    // `runm.provider` isn't ownable by a project, but a `runm.machine` is)
+    string project = 3;
+    // The object's globally-unique identifier
+    string uuid = 4;
+    // The object's human-readable name, unique within the scope of the object
+    // type and partition, and optionall the project.
+    string name = 5;
+    // The collection of key/value properties associated with the object
     repeated Property properties = 50;
+    // The collection of simple string tags associated with the object
+    repeated string tags = 51;
 }

--- a/proto/defs/object_type.proto
+++ b/proto/defs/object_type.proto
@@ -2,11 +2,24 @@ syntax = "proto3";
 
 package runm;
 
+// Indicates the scope of a type of object. The object type's scope indicates
+// the level at which an object's name is guaranteed to be unique. Objects that
+// have an object type with a PROJECT object type scope must be created with a
+// specific project identifier. Objects with a PARTITION object type scope must
+// be created with a partition UUID.
+enum ObjectTypeScope {
+    PARTITION = 0;
+    PROJECT = 1;
+}
+
 // An object type is a simple classification for various types of things known
 // to the runm system
 message ObjectType {
     string code = 1;
     string description = 2;
+    // Indicates the scope that names of objects of this type must guarantee
+    // uniqueness for
+    ObjectTypeScope scope = 3;
 }
 
 // Used in matching object type records

--- a/proto/defs/object_type.proto
+++ b/proto/defs/object_type.proto
@@ -8,3 +8,11 @@ message ObjectType {
     string code = 1;
     string description = 2;
 }
+
+// Used in matching object type records
+message ObjectTypeFilter {
+    // A search term on the object type's string code
+    string search = 1;
+    // Indicates the search should be a prefix expression
+    bool use_prefix = 2;
+}

--- a/proto/defs/partition.proto
+++ b/proto/defs/partition.proto
@@ -12,7 +12,10 @@ message Partition {
     string name = 2;
 }
 
+// Used in matching partition records
 message PartitionFilter {
     // UUID or human-readable name of the partition
     string search = 1;
+    // Indicates the search should be a prefix expression
+    bool use_prefix = 2;
 }

--- a/proto/defs/partition.proto
+++ b/proto/defs/partition.proto
@@ -11,3 +11,8 @@ message Partition {
     string uuid = 1;
     string name = 2;
 }
+
+message PartitionFilter {
+    // UUID or human-readable name of the partition
+    string search = 1;
+}

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -107,15 +107,7 @@ message PartitionListRequest {
 
 message ObjectTypeGetRequest {
     Session session = 1;
-    // An exact-match search term on the object type's string code
-    string code = 2;
-}
-
-message ObjectTypeFilter {
-    // A search term on the object type's string code
-    string code = 1;
-    // Indicates the search should be a prefix expression
-    bool use_prefix = 2;
+    ObjectTypeFilter filter = 2;
 }
 
 message ObjectTypeListRequest {

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -96,19 +96,13 @@ message BootstrapResponse {
 
 message PartitionGetRequest {
     Session session = 1;
-    string search = 2;
-}
-
-message PartitionListFilters {
-    // May be a UUID or a human-readable name. List multiple identifiers to
-    // filter on any of the supplied identifiers.
-    repeated string identifiers = 1;
+    PartitionFilter filter = 2;
 }
 
 message PartitionListRequest {
     Session session = 1;
-    PartitionListFilters filters = 2;
-    SearchOptions options = 3;
+    SearchOptions options = 2;
+    repeated PartitionFilter any = 3;
 }
 
 message ObjectTypeGetRequest {

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -140,19 +140,12 @@ message ObjectSetResponse {
     Object object = 2;
 }
 
-message ObjectListFilters {
-    repeated Partition partitions = 1;
-    repeated ObjectType object_types = 2;
-    repeated string uuids = 3;
-    repeated string names = 4;
-}
-
 message ObjectListRequest {
     Session session = 1;
-    ObjectListFilters filters = 2;
-    SearchOptions options = 3;
-    // When grabbing object information, fetch the object's properties
-    bool fetch_properties = 50;
+    SearchOptions options = 2;
+    // A set of filter expressions that are OR'd together when determining
+    // matches
+    repeated ObjectFilter any = 3;
 }
 
 message ObjectDeleteRequest {


### PR DESCRIPTION
Adds storage layer and gRPC API layer implementation of an object list operation. Objects may be filtered by partition (including with a partition name prefix), object type (including with a name/code prefix) along with object name/prefix and UUID matches.

This includes quite a bit of work in standardizing the way that objects, partitions and object types are filtered, along with some utility code for normalizing and checking if a subject string is like a UUID.

Issue #43 