### PR TITLE
Return ErrDuplicate when object keys already exist

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -11,7 +11,7 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("ERROR(%d): %s", e.Code, e.Message)
+	return fmt.Sprintf("[%d] %s", e.Code, e.Message)
 }
 
 var (

--- a/pkg/metadata/storage/object.go
+++ b/pkg/metadata/storage/object.go
@@ -220,12 +220,7 @@ func (s *Store) ObjectCreate(
 		s.log.ERR("object_create: failed to create txn in etcd: %v", err)
 		return nil, errors.ErrUnknown
 	} else if resp.Succeeded == false {
-		s.log.L3(
-			"object_create: another thread already created object %s:%s",
-			"partition="+obj.Partition,
-			obj.Name,
-		)
-		return nil, errors.ErrUnknown
+		return nil, errors.ErrDuplicate
 	}
 	return obj, nil
 }


### PR DESCRIPTION
Return ErrDuplicate instead ErrUnknown when attempting to create an
object that already exists.