### PR TITLE
Correct two object listing and creating bugs

### DIFF
--- a/pkg/metadata/storage/object_type.go
+++ b/pkg/metadata/storage/object_type.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"strings"
+
 	etcd "github.com/coreos/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 
@@ -63,7 +65,8 @@ func (s *Store) ensureObjectTypes() error {
 	}
 	all := make(map[string]bool, 0)
 	for _, k := range resp.Kvs {
-		all[string(k.Key)] = true
+		otCode := strings.TrimPrefix(string(k.Key), _OBJECT_TYPES_KEY)
+		all[otCode] = true
 	}
 
 	for _, ot := range runmObjectTypes {
@@ -177,8 +180,7 @@ func (s *Store) objectTypeCreate(
 		s.log.ERR("failed to create txn in etcd: %v", err)
 		return err
 	} else if resp.Succeeded == false {
-		s.log.L3("another thread already created key %s", key)
-		return errors.ErrGenerationConflict
+		return errors.ErrDuplicate
 	}
 	return nil
 }

--- a/tests/data/objects/runm.image.yaml
+++ b/tests/data/objects/runm.image.yaml
@@ -1,0 +1,4 @@
+partition: part0
+type: runm.image
+project: proj0
+name: db-server

--- a/tests/data/objects/runm.provider.yaml
+++ b/tests/data/objects/runm.provider.yaml
@@ -1,0 +1,3 @@
+partition: part0
+type: runm.provider
+name: row1-rack1-compute23

--- a/tests/data/propschema.yaml
+++ b/tests/data/propschema.yaml
@@ -1,0 +1,5 @@
+partition: p0
+object_type: runm.machine
+key: architecture
+schema:
+  blah


### PR DESCRIPTION
Addresses an issue where doing a `runm object list --filter "object=<UUID>" wasn't returning results. We were improperly constructing PartitionObjectFilter objects in the metadata server layer when a partition had not been specified.

Also corrects a bug where `ensureObjectTypes()`, which runs on the storage layer's initialization, wasn't properly stripping keys from etcd of the `_OBJECT_TYPES_KEY` prefix before comparing to the well-known object type codes.

Issue #49