### PR TITLE
more fixes for `runm object list` bugs

### DIFF
--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -50,10 +50,10 @@ func (s *Server) buildPartitionObjectFilters(
 		}
 		defer cur.Close()
 
-		var part pb.Partition
 		nParts := 0
 		for cur.Next() {
-			if err = cur.Scan(&part); err != nil {
+			part := &pb.Partition{}
+			if err = cur.Scan(part); err != nil {
 				return nil, err
 			}
 			partUuids[part.Uuid] = true
@@ -71,10 +71,10 @@ func (s *Server) buildPartitionObjectFilters(
 		}
 		defer cur.Close()
 
-		var ot pb.ObjectType
 		nTypes := 0
 		for cur.Next() {
-			if err = cur.Scan(&ot); err != nil {
+			ot := &pb.ObjectType{}
+			if err = cur.Scan(ot); err != nil {
 				return nil, err
 			}
 			otCodes[ot.Code] = true
@@ -188,12 +188,12 @@ func (s *Server) ObjectList(
 		return err
 	}
 	defer cur.Close()
-	var msg pb.Object
 	for cur.Next() {
-		if err = cur.Scan(&msg); err != nil {
+		msg := &pb.Object{}
+		if err = cur.Scan(msg); err != nil {
 			return err
 		}
-		if err = stream.Send(&msg); err != nil {
+		if err = stream.Send(msg); err != nil {
 			return err
 		}
 	}

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -108,22 +108,26 @@ func (s *Server) buildPartitionObjectFilters(
 	// partition filters, then go ahead and just return a single
 	// PartitionObjectFilter with the search term and prefix indicator for the
 	// object.
-	if len(res) > 0 {
-		// Now that we've expanded our partitions and object types, add in the
-		// original ObjectFilter's Search and UsePrefix for each
-		// PartitionObjectFilter we've created
-		for _, pf := range res {
-			pf.Search = filter.Search
-			pf.UsePrefix = filter.UsePrefix
+	if filter.Search != "" || filter.Project != "" {
+		if len(res) > 0 {
+			// Now that we've expanded our partitions and object types, add in the
+			// original ObjectFilter's Search and UsePrefix for each
+			// PartitionObjectFilter we've created
+			for _, pf := range res {
+				pf.Project = filter.Project
+				pf.Search = filter.Search
+				pf.UsePrefix = filter.UsePrefix
+			}
+		} else {
+			res = append(
+				res,
+				&storage.PartitionObjectFilter{
+					Project:   filter.Project,
+					Search:    filter.Search,
+					UsePrefix: filter.UsePrefix,
+				},
+			)
 		}
-	} else {
-		res = append(
-			res,
-			&storage.PartitionObjectFilter{
-				Search:    filter.Search,
-				UsePrefix: filter.UsePrefix,
-			},
-		)
 	}
 	return res, nil
 }

--- a/pkg/metadata/object_type.go
+++ b/pkg/metadata/object_type.go
@@ -40,12 +40,12 @@ func (s *Server) ObjectTypeList(
 		return err
 	}
 	defer cur.Close()
-	var msg pb.ObjectType
 	for cur.Next() {
-		if err = cur.Scan(&msg); err != nil {
+		msg := &pb.ObjectType{}
+		if err = cur.Scan(msg); err != nil {
 			return err
 		}
-		if err = stream.Send(&msg); err != nil {
+		if err = stream.Send(msg); err != nil {
 			return err
 		}
 	}

--- a/pkg/metadata/partition.go
+++ b/pkg/metadata/partition.go
@@ -44,12 +44,12 @@ func (s *Server) PartitionList(
 		return err
 	}
 	defer cur.Close()
-	var msg pb.Partition
 	for cur.Next() {
-		if err = cur.Scan(&msg); err != nil {
+		msg := &pb.Partition{}
+		if err = cur.Scan(msg); err != nil {
 			return err
 		}
-		if err = stream.Send(&msg); err != nil {
+		if err = stream.Send(msg); err != nil {
 			return err
 		}
 	}

--- a/pkg/metadata/property.go
+++ b/pkg/metadata/property.go
@@ -120,12 +120,12 @@ func (s *Server) PropertySchemaList(
 		return err
 	}
 	defer cur.Close()
-	var msg pb.PropertySchema
 	for cur.Next() {
-		if err = cur.Scan(&msg); err != nil {
+		msg := &pb.PropertySchema{}
+		if err = cur.Scan(msg); err != nil {
 			return err
 		}
-		if err = stream.Send(&msg); err != nil {
+		if err = stream.Send(msg); err != nil {
 			return err
 		}
 	}

--- a/pkg/metadata/storage/object.go
+++ b/pkg/metadata/storage/object.go
@@ -86,6 +86,10 @@ func (s *Store) ObjectList(
 	objs := make(map[string]*pb.Object, 0)
 
 	for _, filter := range any {
+		if filter.IsEmpty() {
+			s.log.ERR("received empty PartitionObjectFilter in ObjectList()")
+			continue
+		}
 		// If the PartitionObjectFilter contains a value for the Search field,
 		// that means we need to look up objects by UUID or name (with an
 		// optional prefix for the name). If no Search field is present, that

--- a/pkg/metadata/storage/object.go
+++ b/pkg/metadata/storage/object.go
@@ -1,6 +1,9 @@
 package storage
 
 import (
+	"fmt"
+	"strconv"
+
 	etcd "github.com/coreos/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 
@@ -37,6 +40,36 @@ type PartitionObjectFilter struct {
 	Search         string
 	UsePrefix      bool
 	// TODO(jaypipes): Add support for property and tag filters
+}
+
+func (f *PartitionObjectFilter) IsEmpty() bool {
+	return f.PartitionUuid == "" && f.ObjectTypeCode == "" && f.Project == "" && f.Search == ""
+}
+
+func (f *PartitionObjectFilter) String() string {
+	attrMap := make(map[string]string, 0)
+	if f.PartitionUuid != "" {
+		attrMap["partition"] = f.PartitionUuid
+	}
+	if f.ObjectTypeCode != "" {
+		attrMap["object_type"] = f.ObjectTypeCode
+	}
+	if f.Project != "" {
+		attrMap["project"] = f.Project
+	}
+	if f.Search != "" {
+		attrMap["search"] = f.Search
+		attrMap["use_prefix"] = strconv.FormatBool(f.UsePrefix)
+	}
+	attrs := ""
+	x := 0
+	for k, v := range attrMap {
+		if x > 0 {
+			attrs += ","
+		}
+		attrs += k + "=" + v
+	}
+	return fmt.Sprintf("PartitionObjectFilter(%s)", attrs)
 }
 
 // ObjectTypeList returns a cursor over zero or more ObjectType

--- a/scripts/exec-runm-command.sh
+++ b/scripts/exec-runm-command.sh
@@ -23,7 +23,6 @@ if [ $? -ne 0 ]; then
     make build
 fi
 
-EXEC_COMMAND="$@"
 ETCD_CONTAINER_NAME=${ETCD_CONTAINER_NAME:-"runm-test-etcd"}
 METADATA_CONTAINER_NAME=${METADATA_CONTAINER_NAME:-"runm-test-metadata"}
 
@@ -63,8 +62,8 @@ fi
 
 print_if_verbose ""
 print_if_verbose "*********************************************************************"
-print_if_verbose "Running \`runm $EXEC_COMMAND\` in single-use docker container..."
+print_if_verbose "Running \`runm $*\` in single-use docker container..."
 print_if_verbose "*********************************************************************"
 print_if_verbose ""
 
-docker run --rm --network host -v $ROOT_DIR/tests/data/:/tests/data runm/runm:$VERSION $EXEC_COMMAND
+docker run --rm --network host -v $ROOT_DIR/tests/data/:/tests/data runm/runm:$VERSION "$@"


### PR DESCRIPTION
This patch fixes a number of bugs in the `runm object list` command and server-side functionality.

Due to a misunderstanding of how the `proto.Merge` function worked, I was mistakenly re-using `proto.Message` objects from previous cursor iteration's `Scan()` calls in current iteration objects. This was addressed by always ensuring that a newly-allocated `proto.Message` object is used inside the `for cur.Next()` loop, thereby eliminating the potential for previously-scanned object fields being used. (Issue #56)

The server side of the `ObjectList` gRPC API was reworked to ensure that the array of `storage.PartitionObjectFilter` objects was sounds, contained no empty filters (Issues #52, #53), and that the Project field was properly populated (Issue #51).

Finally, the `scripts/exec-runm-command.sh` was reworked to deal with Bash idiosyncrasies that had to do with how CLI arguments containing quotes were passed to another script or function. (Issue #57)