### PR TITLE
finalize object list operations

### DIFF
--- a/pkg/metadata/auth.go
+++ b/pkg/metadata/auth.go
@@ -1,0 +1,18 @@
+package metadata
+
+import (
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+func checkSession(sess *pb.Session) error {
+	if sess.User == "" {
+		return ErrSessionUserRequired
+	}
+	if sess.Partition == "" {
+		return ErrSessionPartitionRequired
+	}
+	if sess.Project == "" {
+		return ErrSessionProjectRequired
+	}
+	return nil
+}

--- a/pkg/metadata/errors.go
+++ b/pkg/metadata/errors.go
@@ -14,6 +14,18 @@ var (
 		codes.NotFound,
 		"object could not be found.",
 	)
+	ErrSessionUserRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"user is required in session.",
+	)
+	ErrSessionPartitionRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"partition is required in session.",
+	)
+	ErrSessionProjectRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"project is required in session.",
+	)
 	ErrPartitionUnknown = status.Errorf(
 		codes.FailedPrecondition,
 		"unknown partition.",

--- a/pkg/metadata/errors.go
+++ b/pkg/metadata/errors.go
@@ -26,6 +26,10 @@ var (
 		codes.FailedPrecondition,
 		"project is required in session.",
 	)
+	ErrFailedExpandObjectFilters = status.Errorf(
+		codes.FailedPrecondition,
+		"failed to expand object filters.",
+	)
 	ErrPartitionUnknown = status.Errorf(
 		codes.FailedPrecondition,
 		"unknown partition.",

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -22,123 +22,6 @@ func (s *Server) ObjectGet(
 	return nil, nil
 }
 
-// expandObjectFilter is used to expand an ObjectFilter, which may contain
-// PartitionFilter and ObjectTypeFilter objects that themselves may resolve to
-// multiple partitions or object types, to a set of PartitionObjectFilter
-// objects. A PartitionObjectFilter is used to describe a filter on objects in
-// a *specific* partition and having a *specific* object type.
-func (s *Server) expandObjectFilter(
-	filter *pb.ObjectFilter,
-) ([]*storage.PartitionObjectFilter, error) {
-	res := make([]*storage.PartitionObjectFilter, 0)
-	// A set of partition UUIDs that we'll create PartitionObjectFilters with.
-	// These are the UUIDs of any partitions that match the PartitionFilter in
-	// the supplied pb.ObjectFilter
-	partitions := make([]*pb.Partition, 0)
-	// A set of object type codes that we'll create PartitionObjectFilters
-	// with. These are the codes of object types that match the
-	// ObjectTypeFilter in the supplied ObjectFilter
-	objTypes := make([]*pb.ObjectType, 0)
-
-	if filter.Partition != nil {
-		// Verify that the requested partition(s) exist(s) and for each
-		// requested partition match, construct a new PartitionObjectFilter
-		cur, err := s.store.PartitionList([]*pb.PartitionFilter{filter.Partition})
-		if err != nil {
-			return nil, err
-		}
-		defer cur.Close()
-
-		for cur.Next() {
-			part := &pb.Partition{}
-			if err = cur.Scan(part); err != nil {
-				return nil, err
-			}
-			partitions = append(partitions, part)
-		}
-		if len(partitions) == 0 {
-			return nil, errors.ErrNotFound
-		}
-	}
-	if filter.ObjectType != nil {
-		// Verify that the object type even exists
-		cur, err := s.store.ObjectTypeList([]*pb.ObjectTypeFilter{filter.ObjectType})
-		if err != nil {
-			return nil, err
-		}
-		defer cur.Close()
-
-		for cur.Next() {
-			ot := &pb.ObjectType{}
-			if err = cur.Scan(ot); err != nil {
-				return nil, err
-			}
-			objTypes = append(objTypes, ot)
-		}
-		if len(objTypes) == 0 {
-			return nil, errors.ErrNotFound
-		}
-	}
-
-	// OK, if we've expanded partition or object type, we need to construct
-	// PartitionObjectFilter objects containing the combination of all the
-	// expanded partitions and object types.
-	if len(partitions) > 0 {
-		for _, p := range partitions {
-			if len(objTypes) == 0 {
-				f := &storage.PartitionObjectFilter{
-					Partition: p,
-				}
-				res = append(res, f)
-			} else {
-				for _, ot := range objTypes {
-					f := &storage.PartitionObjectFilter{
-						Partition:  p,
-						ObjectType: ot,
-					}
-					res = append(res, f)
-				}
-			}
-		}
-	} else if len(objTypes) > 0 {
-		for _, ot := range objTypes {
-			f := &storage.PartitionObjectFilter{
-				ObjectType: ot,
-			}
-			res = append(res, f)
-		}
-	}
-
-	// If we've expanded the supplied partition filters into multiple
-	// PartitionObjectFilters, then we need to add our supplied ObjectFilter's
-	// search and use prefix for the object's UUID/name. If we supplied no
-	// partition filters, then go ahead and just return a single
-	// PartitionObjectFilter with the search term and prefix indicator for the
-	// object.
-	if filter.Search != "" || filter.Project != "" {
-		if len(res) > 0 {
-			// Now that we've expanded our partitions and object types, add in the
-			// original ObjectFilter's Search and UsePrefix for each
-			// PartitionObjectFilter we've created
-			for _, pf := range res {
-				pf.Project = filter.Project
-				pf.Search = filter.Search
-				pf.UsePrefix = filter.UsePrefix
-			}
-		} else {
-			res = append(
-				res,
-				&storage.PartitionObjectFilter{
-					Project:   filter.Project,
-					Search:    filter.Search,
-					UsePrefix: filter.UsePrefix,
-				},
-			)
-		}
-	}
-	return res, nil
-}
-
 func (s *Server) ObjectList(
 	req *pb.ObjectListRequest,
 	stream pb.RunmMetadata_ObjectListServer,
@@ -148,7 +31,7 @@ func (s *Server) ObjectList(
 	}
 	any := make([]*storage.PartitionObjectFilter, 0)
 	for _, filter := range req.Any {
-		if pfs, err := s.expandObjectFilter(filter); err != nil {
+		if pfs, err := s.expandObjectFilter(req.Session, filter); err != nil {
 			if err == errors.ErrNotFound {
 				// Just continue since clearly we can have no objects matching
 				// an unknown partition but we need to OR together all filters,
@@ -164,39 +47,18 @@ func (s *Server) ObjectList(
 	}
 
 	if len(any) == 0 {
-		if len(req.Any) > 0 {
-			// If the user specified filters but due to specifying unknown
-			// partitions or object types, there were no non-empty filters
-			// produced, we return nil to indicate no records were found
-			s.log.L3(
-				"object_list: no partition object filters created from %s",
-				req.Any,
-			)
+		if len(req.Any) == 0 {
+			// At least one filter should have been expanded
+			defFilter, err := s.defaultObjectFilter(req.Session)
+			if err != nil {
+				return ErrFailedExpandObjectFilters
+			}
+			any = append(any, defFilter)
+		} else {
+			// The user asked for object types that don't exist, partitions
+			// that don't exist, etc.
 			return nil
 		}
-		// By default, filter by the session's partition if the user didn't
-		// specify any filtering.
-		part, err := s.store.PartitionGet(req.Session.Partition)
-		if err != nil {
-			if err == errors.ErrNotFound {
-				// Just return nil since clearly we can have no
-				// property schemas matching an unknown partition
-				s.log.L3(
-					"object_list: '%s' listed objects with no filters "+
-						"and supplied unknown partition '%s' in the session",
-					req.Session.User,
-					req.Session.Partition,
-				)
-				return nil
-			}
-			return errors.ErrUnknown
-		}
-		any = append(
-			any,
-			&storage.PartitionObjectFilter{
-				Partition: part,
-			},
-		)
 	}
 
 	cur, err := s.store.ObjectList(any)

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -174,7 +174,7 @@ func (s *Server) ObjectList(
 				// Just return nil since clearly we can have no
 				// property schemas matching an unknown partition
 				s.log.L3(
-					"object_list: user %s listed objects with no filters "+
+					"object_list: '%s' listed objects with no filters "+
 						"and supplied unknown partition '%s' in the session",
 					req.Session.User,
 					req.Session.Partition,

--- a/pkg/metadata/object_filter.go
+++ b/pkg/metadata/object_filter.go
@@ -1,0 +1,169 @@
+package metadata
+
+import (
+	"github.com/runmachine-io/runmachine/pkg/errors"
+	"github.com/runmachine-io/runmachine/pkg/metadata/storage"
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+// defaultObjectFilter returns the default partition object filter if the user
+// didn't specify any filters themselves. This filter will be across the
+// partition that the user's session is on.
+func (s *Server) defaultObjectFilter(
+	session *pb.Session,
+) (*storage.PartitionObjectFilter, error) {
+	part, err := s.store.PartitionGet(session.Partition)
+	if err != nil {
+		if err == errors.ErrNotFound {
+			// Just return nil since clearly we can have no
+			// property schemas matching an unknown partition
+			s.log.L3(
+				"'%s' listed objects with no filters "+
+					"and supplied unknown partition '%s' in the session",
+				session.User,
+				session.Partition,
+			)
+		}
+		return nil, err
+	}
+	return &storage.PartitionObjectFilter{
+		Partition: part,
+	}, nil
+}
+
+// expandObjectFilter is used to expand an ObjectFilter, which may contain
+// PartitionFilter and ObjectTypeFilter objects that themselves may resolve to
+// multiple partitions or object types, to a set of PartitionObjectFilter
+// objects. A PartitionObjectFilter is used to describe a filter on objects in
+// a *specific* partition and having a *specific* object type.
+func (s *Server) expandObjectFilter(
+	session *pb.Session,
+	filter *pb.ObjectFilter,
+) ([]*storage.PartitionObjectFilter, error) {
+	res := make([]*storage.PartitionObjectFilter, 0)
+	// A set of partition UUIDs that we'll create PartitionObjectFilters with.
+	// These are the UUIDs of any partitions that match the PartitionFilter in
+	// the supplied pb.ObjectFilter
+	partitions := make([]*pb.Partition, 0)
+	// A set of object type codes that we'll create PartitionObjectFilters
+	// with. These are the codes of object types that match the
+	// ObjectTypeFilter in the supplied ObjectFilter
+	objTypes := make([]*pb.ObjectType, 0)
+
+	if filter.Partition != nil {
+		// Verify that the requested partition(s) exist(s) and for each
+		// requested partition match, construct a new PartitionObjectFilter
+		cur, err := s.store.PartitionList([]*pb.PartitionFilter{filter.Partition})
+		if err != nil {
+			return nil, err
+		}
+		defer cur.Close()
+
+		for cur.Next() {
+			part := &pb.Partition{}
+			if err = cur.Scan(part); err != nil {
+				return nil, err
+			}
+			partitions = append(partitions, part)
+		}
+		if len(partitions) == 0 {
+			return nil, errors.ErrNotFound
+		}
+	} else {
+		// By default, filter by the session's partition if the user didn't
+		// specify any filtering.
+		part, err := s.store.PartitionGet(session.Partition)
+		if err != nil {
+			if err == errors.ErrNotFound {
+				// Just return nil since clearly we can have no
+				// property schemas matching an unknown partition
+				s.log.L3(
+					"'%s' listed objects with no filters "+
+						"and supplied unknown partition '%s' in the session",
+					session.User,
+					session.Partition,
+				)
+			}
+			return nil, err
+		}
+		partitions = append(partitions, part)
+	}
+
+	if filter.ObjectType != nil {
+		// Verify that the object type even exists
+		cur, err := s.store.ObjectTypeList([]*pb.ObjectTypeFilter{filter.ObjectType})
+		if err != nil {
+			return nil, err
+		}
+		defer cur.Close()
+
+		for cur.Next() {
+			ot := &pb.ObjectType{}
+			if err = cur.Scan(ot); err != nil {
+				return nil, err
+			}
+			objTypes = append(objTypes, ot)
+		}
+		if len(objTypes) == 0 {
+			return nil, errors.ErrNotFound
+		}
+	}
+
+	// OK, if we've expanded partition or object type, we need to construct
+	// PartitionObjectFilter objects containing the combination of all the
+	// expanded partitions and object types.
+	if len(partitions) > 0 {
+		for _, p := range partitions {
+			if len(objTypes) == 0 {
+				f := &storage.PartitionObjectFilter{
+					Partition: p,
+				}
+				res = append(res, f)
+			} else {
+				for _, ot := range objTypes {
+					f := &storage.PartitionObjectFilter{
+						Partition:  p,
+						ObjectType: ot,
+					}
+					res = append(res, f)
+				}
+			}
+		}
+	} else if len(objTypes) > 0 {
+		for _, ot := range objTypes {
+			f := &storage.PartitionObjectFilter{
+				ObjectType: ot,
+			}
+			res = append(res, f)
+		}
+	}
+
+	// If we've expanded the supplied partition filters into multiple
+	// PartitionObjectFilters, then we need to add our supplied ObjectFilter's
+	// search and use prefix for the object's UUID/name. If we supplied no
+	// partition filters, then go ahead and just return a single
+	// PartitionObjectFilter with the search term and prefix indicator for the
+	// object.
+	if filter.Search != "" || filter.Project != "" {
+		if len(res) > 0 {
+			// Now that we've expanded our partitions and object types, add in the
+			// original ObjectFilter's Search and UsePrefix for each
+			// PartitionObjectFilter we've created
+			for _, pf := range res {
+				pf.Project = filter.Project
+				pf.Search = filter.Search
+				pf.UsePrefix = filter.UsePrefix
+			}
+		} else {
+			res = append(
+				res,
+				&storage.PartitionObjectFilter{
+					Project:   filter.Project,
+					Search:    filter.Search,
+					UsePrefix: filter.UsePrefix,
+				},
+			)
+		}
+	}
+	return res, nil
+}

--- a/pkg/metadata/object_filter.go
+++ b/pkg/metadata/object_filter.go
@@ -28,6 +28,7 @@ func (s *Server) defaultObjectFilter(
 	}
 	return &storage.PartitionObjectFilter{
 		Partition: part,
+		Project:   session.Project,
 	}, nil
 }
 
@@ -107,6 +108,15 @@ func (s *Server) expandObjectFilter(
 		if len(objTypes) == 0 {
 			return nil, errors.ErrNotFound
 		}
+	}
+
+	// Default the object list to filtering by the session's project if the
+	// user didn't specify a specific project to filter on
+	if filter.Project == "" {
+		filter.Project = session.Project
+	} else {
+		// TODO(jaypipes): Determine if the user has the ability to list
+		// objects in other projects...
 	}
 
 	// OK, if we've expanded partition or object type, we need to construct

--- a/pkg/metadata/storage/object.go
+++ b/pkg/metadata/storage/object.go
@@ -169,7 +169,7 @@ func (s *Store) objectsGetByFilter(
 			// scan on all objects by the primary objects/by-uuid/ index and
 			// manually check to see if the deserialized Object's name has the
 			// requested name...
-			if filter.ObjectType != nil {
+			if filter.ObjectType != nil && filter.Partition != nil {
 				// TODO(jaypipes)
 				return []*pb.Object{}, nil
 			}

--- a/scripts/exec-runm-command.sh
+++ b/scripts/exec-runm-command.sh
@@ -66,4 +66,12 @@ print_if_verbose "Running \`runm $*\` in single-use docker container..."
 print_if_verbose "*********************************************************************"
 print_if_verbose ""
 
-docker run --rm --network host -v $ROOT_DIR/tests/data/:/tests/data runm/runm:$VERSION "$@"
+runm_user=${RUNM_USER:-admin}
+runm_project=${RUNM_PROJECT:-project0}
+runm_partition=${RUNM_PARTITION:-part0}
+
+docker run --rm --network host -v $ROOT_DIR/tests/data/:/tests/data \
+    -e RUNM_USER="$runm_user" \
+    -e RUNM_PROJECT="$runm_project" \
+    -e RUNM_PARTITION="$runm_partition" \
+    runm/runm:$VERSION "$@"

--- a/scripts/exec-runm-command.sh
+++ b/scripts/exec-runm-command.sh
@@ -67,7 +67,7 @@ print_if_verbose "**************************************************************
 print_if_verbose ""
 
 runm_user=${RUNM_USER:-admin}
-runm_project=${RUNM_PROJECT:-project0}
+runm_project=${RUNM_PROJECT:-proj0}
 runm_partition=${RUNM_PARTITION:-part0}
 
 docker run --rm --network host -v $ROOT_DIR/tests/data/:/tests/data \


### PR DESCRIPTION
Finishes off the object listing work by adding support for default object filters (being constructed from the Session object's partition and project information), adding support for name-based index lookups in etcd, and modifying PartitionObjectFilter to have actual Partition and ObjectType message pointers instead of partition UUID and object type code.

Issue #43 