### PR TITLE
implement runm object get command

### DIFF
--- a/cmd/runm/commands/common.go
+++ b/cmd/runm/commands/common.go
@@ -68,7 +68,7 @@ func exitIfConnectErr(err error) {
 func exitIfError(err error) {
 	if s, ok := status.FromError(err); ok {
 		if s.Code() != codes.OK {
-			fmt.Printf("Error: %s\n", s.Message())
+			fmt.Fprintf(os.Stderr, "Error: %s\n", s.Message())
 			os.Exit(int(s.Code()))
 		}
 	}

--- a/cmd/runm/commands/object.go
+++ b/cmd/runm/commands/object.go
@@ -11,5 +11,6 @@ var objectCommand = &cobra.Command{
 
 func init() {
 	objectCommand.AddCommand(objectListCommand)
+	objectCommand.AddCommand(objectGetCommand)
 	objectCommand.AddCommand(objectCreateCommand)
 }

--- a/cmd/runm/commands/object_get.go
+++ b/cmd/runm/commands/object_get.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+
+	"github.com/runmachine-io/runmachine/pkg/util"
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+const (
+	usageObjectGetType = `specify the object type.
+
+Required when <search> is not a UUID.
+`
+)
+
+var (
+	// CLI-provided --type value
+	cliObjectGetType string
+)
+
+var objectGetCommand = &cobra.Command{
+	Use:   "get <search>",
+	Short: "Show information for a single object",
+	Args:  cobra.ExactArgs(1),
+	Run:   objectGet,
+}
+
+func setupObjectGetFlags() {
+	objectGetCommand.Flags().StringVarP(
+		&cliObjectGetType,
+		"type", "t", "",
+		usageObjectGetType,
+	)
+}
+
+func init() {
+	setupObjectGetFlags()
+}
+
+func objectGet(cmd *cobra.Command, args []string) {
+	conn := connect()
+	defer conn.Close()
+
+	client := pb.NewRunmMetadataClient(conn)
+
+	session := getSession()
+	uuidOrName := args[0]
+	search := &pb.ObjectFilter{
+		Search:    uuidOrName,
+		UsePrefix: false,
+	}
+
+	if !util.IsUuidLike(uuidOrName) {
+		if cliObjectGetType == "" {
+			fmt.Fprintf(os.Stderr, "Error: --type required when <search> is not a UUID\n")
+			os.Exit(1)
+		}
+		search.ObjectType = &pb.ObjectTypeFilter{
+			Search:    cliObjectGetType,
+			UsePrefix: false,
+		}
+	}
+	obj, err := client.ObjectGet(
+		context.Background(),
+		&pb.ObjectGetRequest{
+			Session: session,
+			Search:  search,
+		},
+	)
+	exitIfError(err)
+	fmt.Printf("Partition: %s\n", obj.Partition)
+	fmt.Printf("Type:      %s\n", obj.ObjectType)
+	fmt.Printf("UUID:      %s\n", obj.Uuid)
+	fmt.Printf("Name:      %s\n", obj.Name)
+	if obj.Project != "" {
+		fmt.Printf("Project:   %s\n", obj.Project)
+	}
+}

--- a/pkg/metadata/errors.go
+++ b/pkg/metadata/errors.go
@@ -30,6 +30,14 @@ var (
 		codes.FailedPrecondition,
 		"failed to expand object filters.",
 	)
+	ErrObjectFilterRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"object filter is required when fetching object.",
+	)
+	ErrMultipleRecordsFound = status.Errorf(
+		codes.FailedPrecondition,
+		"multiple records found (expected single record match).",
+	)
 	ErrPartitionUnknown = status.Errorf(
 		codes.FailedPrecondition,
 		"unknown partition.",

--- a/pkg/metadata/storage/object.go
+++ b/pkg/metadata/storage/object.go
@@ -146,7 +146,7 @@ func (s *Store) objectsGetByFilter(
 					return nil, errors.ErrNotFound
 				}
 			}
-			if filter.Project != "" {
+			if filter.Project != "" && obj.Project != "" {
 				if obj.Project != filter.Project {
 					return nil, errors.ErrNotFound
 				}
@@ -220,7 +220,7 @@ func (s *Store) objectsGetByFilter(
 				continue
 			}
 		}
-		if filter.Project != "" {
+		if filter.Project != "" && obj.Project != "" {
 			if obj.Project != filter.Project {
 				continue
 			}

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -120,7 +120,7 @@ message ObjectTypeListRequest {
 
 message ObjectGetRequest {
     Session session = 1;
-    string search = 2;
+    ObjectFilter search = 2;
 }
 
 message ObjectSetFields {


### PR DESCRIPTION
Adds a new `runm object get <search>` command that accepts either a UUID
or name and looks up a single object record. If a name is specified
instead of a UUID, then the --type flag is required.

```
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh object get
8dd1e156a27e43c7b17543221c999912
Partition: ace2f2f1016c4922ac0be16cad6a32f2
Type:      runm.image
UUID:      8dd1e156a27e43c7b17543221c999912
Name:      db-server
Project:   proj0
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh object get
db-server
Error: --type required when <search> is not a UUID
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh object get
db-server --type runm.image
Partition: ace2f2f1016c4922ac0be16cad6a32f2
Type:      runm.image
UUID:      8dd1e156a27e43c7b17543221c999912
Name:      db-server
Project:   proj0
```

Issue #43