### PR TITLE
rename PartitionObjectFilter to ObjectListFilter

### DIFF
--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -71,7 +71,7 @@ func (s *Server) ObjectList(
 	if err := checkSession(req.Session); err != nil {
 		return err
 	}
-	any := make([]*storage.PartitionObjectFilter, 0)
+	any := make([]*storage.ObjectListFilter, 0)
 	for _, filter := range req.Any {
 		if pfs, err := s.expandObjectFilter(req.Session, filter); err != nil {
 			if err == errors.ErrNotFound {

--- a/pkg/metadata/object_filter.go
+++ b/pkg/metadata/object_filter.go
@@ -11,7 +11,7 @@ import (
 // partition that the user's session is on.
 func (s *Server) defaultObjectFilter(
 	session *pb.Session,
-) (*storage.PartitionObjectFilter, error) {
+) (*storage.ObjectListFilter, error) {
 	part, err := s.store.PartitionGet(session.Partition)
 	if err != nil {
 		if err == errors.ErrNotFound {
@@ -26,7 +26,7 @@ func (s *Server) defaultObjectFilter(
 		}
 		return nil, err
 	}
-	return &storage.PartitionObjectFilter{
+	return &storage.ObjectListFilter{
 		Partition: part,
 		Project:   session.Project,
 	}, nil
@@ -34,26 +34,26 @@ func (s *Server) defaultObjectFilter(
 
 // expandObjectFilter is used to expand an ObjectFilter, which may contain
 // PartitionFilter and ObjectTypeFilter objects that themselves may resolve to
-// multiple partitions or object types, to a set of PartitionObjectFilter
-// objects. A PartitionObjectFilter is used to describe a filter on objects in
+// multiple partitions or object types, to a set of ObjectListFilter
+// objects. A ObjectListFilter is used to describe a filter on objects in
 // a *specific* partition and having a *specific* object type.
 func (s *Server) expandObjectFilter(
 	session *pb.Session,
 	filter *pb.ObjectFilter,
-) ([]*storage.PartitionObjectFilter, error) {
-	res := make([]*storage.PartitionObjectFilter, 0)
-	// A set of partition UUIDs that we'll create PartitionObjectFilters with.
+) ([]*storage.ObjectListFilter, error) {
+	res := make([]*storage.ObjectListFilter, 0)
+	// A set of partition UUIDs that we'll create ObjectListFilters with.
 	// These are the UUIDs of any partitions that match the PartitionFilter in
 	// the supplied pb.ObjectFilter
 	partitions := make([]*pb.Partition, 0)
-	// A set of object type codes that we'll create PartitionObjectFilters
+	// A set of object type codes that we'll create ObjectListFilters
 	// with. These are the codes of object types that match the
 	// ObjectTypeFilter in the supplied ObjectFilter
 	objTypes := make([]*pb.ObjectType, 0)
 
 	if filter.Partition != nil {
 		// Verify that the requested partition(s) exist(s) and for each
-		// requested partition match, construct a new PartitionObjectFilter
+		// requested partition match, construct a new ObjectListFilter
 		cur, err := s.store.PartitionList([]*pb.PartitionFilter{filter.Partition})
 		if err != nil {
 			return nil, err
@@ -120,18 +120,18 @@ func (s *Server) expandObjectFilter(
 	}
 
 	// OK, if we've expanded partition or object type, we need to construct
-	// PartitionObjectFilter objects containing the combination of all the
+	// ObjectListFilter objects containing the combination of all the
 	// expanded partitions and object types.
 	if len(partitions) > 0 {
 		for _, p := range partitions {
 			if len(objTypes) == 0 {
-				f := &storage.PartitionObjectFilter{
+				f := &storage.ObjectListFilter{
 					Partition: p,
 				}
 				res = append(res, f)
 			} else {
 				for _, ot := range objTypes {
-					f := &storage.PartitionObjectFilter{
+					f := &storage.ObjectListFilter{
 						Partition:  p,
 						ObjectType: ot,
 					}
@@ -141,7 +141,7 @@ func (s *Server) expandObjectFilter(
 		}
 	} else if len(objTypes) > 0 {
 		for _, ot := range objTypes {
-			f := &storage.PartitionObjectFilter{
+			f := &storage.ObjectListFilter{
 				ObjectType: ot,
 			}
 			res = append(res, f)
@@ -149,16 +149,16 @@ func (s *Server) expandObjectFilter(
 	}
 
 	// If we've expanded the supplied partition filters into multiple
-	// PartitionObjectFilters, then we need to add our supplied ObjectFilter's
+	// ObjectListFilters, then we need to add our supplied ObjectFilter's
 	// search and use prefix for the object's UUID/name. If we supplied no
 	// partition filters, then go ahead and just return a single
-	// PartitionObjectFilter with the search term and prefix indicator for the
+	// ObjectListFilter with the search term and prefix indicator for the
 	// object.
 	if filter.Search != "" || filter.Project != "" {
 		if len(res) > 0 {
 			// Now that we've expanded our partitions and object types, add in the
 			// original ObjectFilter's Search and UsePrefix for each
-			// PartitionObjectFilter we've created
+			// ObjectListFilter we've created
 			for _, pf := range res {
 				pf.Project = filter.Project
 				pf.Search = filter.Search
@@ -167,7 +167,7 @@ func (s *Server) expandObjectFilter(
 		} else {
 			res = append(
 				res,
-				&storage.PartitionObjectFilter{
+				&storage.ObjectListFilter{
 					Project:   filter.Project,
 					Search:    filter.Search,
 					UsePrefix: filter.UsePrefix,


### PR DESCRIPTION
The original intention of PartitionObjectFilter was to house a concrete
filter for objects that contained a specific partition identifier,
however we also added a specific object type identifier, so this patch
just renamed PartitionObjectFilter to ObjectListFilter which is better
for describing what this class does.