### PR TITLE
object work and cleanup

### DIFF
--- a/cmd/runm/commands/object_create.go
+++ b/cmd/runm/commands/object_create.go
@@ -58,10 +58,10 @@ func getObjectFromBytes(b []byte) (*pb.Object, error) {
 	}
 	return &pb.Object{
 		// The server actually will translate partition names to UUIDs...
-		Partition:  od.Partition,
-		ObjectType: od.Type,
-		Project:    od.Project,
-		Name:       od.Name,
+		Partition: od.Partition,
+		Type:      od.Type,
+		Project:   od.Project,
+		Name:      od.Name,
 	}, nil
 }
 
@@ -110,7 +110,7 @@ func objectCreate(cmd *cobra.Command, args []string) {
 	obj = resp.Object
 	if !quiet {
 		fmt.Printf("UUID:        %s\n", obj.Uuid)
-		fmt.Printf("Type:        %s\n", obj.ObjectType)
+		fmt.Printf("Type:        %s\n", obj.Type)
 		fmt.Printf("Partition:   %s\n", obj.Partition)
 		fmt.Printf("Name:        %s\n", obj.Name)
 		fmt.Printf("Project:     %s\n", obj.Project)

--- a/cmd/runm/commands/object_create.go
+++ b/cmd/runm/commands/object_create.go
@@ -1,20 +1,12 @@
 package commands
 
 import (
-	"bufio"
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	"golang.org/x/net/context"
 
 	pb "github.com/runmachine-io/runmachine/proto"
 	"github.com/spf13/cobra"
-)
-
-var (
-	// optional filepath to read the object file containing the schema from
-	objectDocPath string
 )
 
 var objectCreateCommand = &cobra.Command{
@@ -40,38 +32,11 @@ func objectCreate(cmd *cobra.Command, args []string) {
 	conn := connect()
 	defer conn.Close()
 
-	// TODO(jaypipes): Move the below generic file-reading into a common helper
-	// function since this is going to be a common pattern for
-	// creating/updating objects.
-	var b []byte
-	if objectDocPath == "" {
-		// User did not specify -f therefore we expect to read the YAML
-		// document from stdin
-		scanner := bufio.NewScanner(os.Stdin)
-		buf := make([]byte, 0)
-		for scanner.Scan() {
-			buf = append(buf, scanner.Bytes()...)
-		}
-		b = buf
-	} else {
-		if buf, err := ioutil.ReadFile(objectDocPath); err != nil {
-			fmt.Printf("Error: %s\n", err)
-			os.Exit(1)
-		} else {
-			b = buf
-		}
-	}
-
-	if len(b) == 0 {
-		fmt.Println("Error: expected to receive object YAML in STDIN")
-		os.Exit(1)
-	}
-
 	client := pb.NewRunmMetadataClient(conn)
 	req := &pb.ObjectSetRequest{
 		Session: getSession(),
 		Format:  pb.PayloadFormat_YAML,
-		Payload: b,
+		Payload: readInputDocumentOrExit(),
 	}
 
 	resp, err := client.ObjectSet(context.Background(), req)

--- a/cmd/runm/commands/object_get.go
+++ b/cmd/runm/commands/object_get.go
@@ -60,7 +60,7 @@ func objectGet(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: --type required when <search> is not a UUID\n")
 			os.Exit(1)
 		}
-		search.ObjectType = &pb.ObjectTypeFilter{
+		search.Type = &pb.ObjectTypeFilter{
 			Search:    cliObjectGetType,
 			UsePrefix: false,
 		}
@@ -74,7 +74,7 @@ func objectGet(cmd *cobra.Command, args []string) {
 	)
 	exitIfError(err)
 	fmt.Printf("Partition: %s\n", obj.Partition)
-	fmt.Printf("Type:      %s\n", obj.ObjectType)
+	fmt.Printf("Type:      %s\n", obj.Type)
 	fmt.Printf("UUID:      %s\n", obj.Uuid)
 	fmt.Printf("Name:      %s\n", obj.Name)
 	if obj.Project != "" {

--- a/cmd/runm/commands/object_list.go
+++ b/cmd/runm/commands/object_list.go
@@ -110,7 +110,7 @@ func buildObjectFilters() []*pb.ObjectFilter {
 					UsePrefix: usePrefix,
 				}
 			case "type":
-				filter.ObjectType = &pb.ObjectTypeFilter{
+				filter.Type = &pb.ObjectTypeFilter{
 					Search:    value,
 					UsePrefix: usePrefix,
 				}
@@ -169,7 +169,7 @@ func objectList(cmd *cobra.Command, args []string) {
 	for x, obj := range msgs {
 		rows[x] = []string{
 			obj.Partition,
-			obj.ObjectType,
+			obj.Type,
 			obj.Uuid,
 			obj.Name,
 			obj.Project,

--- a/pkg/api/types/object.go
+++ b/pkg/api/types/object.go
@@ -1,0 +1,36 @@
+package types
+
+// I would much prefer to be able to decorate our primary Protobuffer models
+// (in proto/defs) with tags that indicate YAML input validation, however the
+// developers of Google Protobuffers are not interested in supporting this
+// feature.
+//
+// Therefore, we need to have separately-defined structs that can be used for
+// YAML input validation and marshaling.
+//
+// :see: https://github.com/golang/protobuf/issues/52
+
+type Object struct {
+	// Identifier of the partition the object belongs to
+	Partition string `yaml:"partition"`
+	// Code for the type of object this is
+	Type string `yaml:"type"`
+	// Optional identifier of the project the object belongs to. Only required
+	// if the object's type is project-scoped
+	Project string `yaml:"project"`
+	// The UUID of the object. Expected to be blank when a user is creating a
+	// new object.
+	Uuid string `yaml:"uuid"`
+	// Human-readable name for the object. Uniqueness is guaranteed in the
+	// scope of the type of object. If the type is project-scoped, then
+	// uniqueness is guaranteed within the scope of the partition, object type
+	// and project. If partition-scoped, uniqueness is guaranteed within the
+	// scope of the partition and object type.
+	Name string `yaml:"name"`
+	// Map of key/value properties associated with this object. Properties can
+	// have a structure and be validated against a schema.
+	Properties map[string]string `yaml:"properties"`
+	// Array of string tags. Tags are unstructured and unvalidated and any user
+	// belonging to the owning project can add or remove any tag.
+	Tags []string `yaml:"tags"`
+}

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -41,3 +41,25 @@ var (
 		Message:  "unknown error.",
 	}
 )
+
+func ErrObjectTypeNotFound(objType string) *Error {
+	return &Error{
+		HTTPCode: 404,
+		Code:     404001,
+		Message: fmt.Sprintf(
+			"object type %s could not be found.",
+			objType,
+		),
+	}
+}
+
+func ErrPartitionNotFound(partition string) *Error {
+	return &Error{
+		HTTPCode: 404,
+		Code:     404002,
+		Message: fmt.Sprintf(
+			"partition %s could not be found.",
+			partition,
+		),
+	}
+}

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -146,7 +146,7 @@ func (s *Server) validateObjectSetRequest(
 	after := req.After
 
 	// Simple input data validations
-	if after.ObjectType == "" {
+	if after.Type == "" {
 		return ErrObjectTypeRequired
 	}
 	if after.Partition == "" {
@@ -165,16 +165,16 @@ func (s *Server) validateObjectSetRequest(
 	}
 	after.Partition = p.Uuid
 
-	ot, err := s.store.ObjectTypeGet(after.ObjectType)
+	ot, err := s.store.ObjectTypeGet(after.Type)
 	if err != nil {
 		if err == errors.ErrNotFound {
-			return errObjectTypeNotFound(after.ObjectType)
+			return errObjectTypeNotFound(after.Type)
 		}
 		// We don't want to leak internal implementation errors...
 		s.log.ERR("failed when validating object type in object set: %s", err)
 		return errors.ErrUnknown
 	}
-	after.ObjectType = ot.Code
+	after.Type = ot.Code
 
 	if req.Before == nil {
 		// TODO(jaypipes): User expects to create a new object with the after
@@ -207,7 +207,7 @@ func (s *Server) ObjectSet(
 	if req.Before == nil {
 		s.log.L3(
 			"creating new object of type %s in partition %s with name %s...",
-			req.After.ObjectType,
+			req.After.Type,
 			req.After.Partition,
 			req.After.Name,
 		)
@@ -218,7 +218,7 @@ func (s *Server) ObjectSet(
 		s.log.L1(
 			"created new object with UUID %s of type %s in partition %s with name %s",
 			changed.Uuid,
-			req.After.ObjectType,
+			req.After.Type,
 			req.After.Partition,
 			req.After.Name,
 		)

--- a/pkg/metadata/object_filter.go
+++ b/pkg/metadata/object_filter.go
@@ -90,9 +90,9 @@ func (s *Server) expandObjectFilter(
 		partitions = append(partitions, part)
 	}
 
-	if filter.ObjectType != nil {
+	if filter.Type != nil {
 		// Verify that the object type even exists
-		cur, err := s.store.ObjectTypeList([]*pb.ObjectTypeFilter{filter.ObjectType})
+		cur, err := s.store.ObjectTypeList([]*pb.ObjectTypeFilter{filter.Type})
 		if err != nil {
 			return nil, err
 		}
@@ -132,8 +132,8 @@ func (s *Server) expandObjectFilter(
 			} else {
 				for _, ot := range objTypes {
 					f := &storage.ObjectListFilter{
-						Partition:  p,
-						ObjectType: ot,
+						Partition: p,
+						Type:      ot,
 					}
 					res = append(res, f)
 				}
@@ -142,7 +142,7 @@ func (s *Server) expandObjectFilter(
 	} else if len(objTypes) > 0 {
 		for _, ot := range objTypes {
 			f := &storage.ObjectListFilter{
-				ObjectType: ot,
+				Type: ot,
 			}
 			res = append(res, f)
 		}

--- a/pkg/metadata/storage/object.go
+++ b/pkg/metadata/storage/object.go
@@ -36,16 +36,16 @@ const (
 // that represent a specific filter on partition UUID and object type, along
 // with the the object's name/UUID and UsePrefix flag.
 type ObjectListFilter struct {
-	Partition  *pb.Partition
-	ObjectType *pb.ObjectType
-	Project    string
-	Search     string
-	UsePrefix  bool
+	Partition *pb.Partition
+	Type      *pb.ObjectType
+	Project   string
+	Search    string
+	UsePrefix bool
 	// TODO(jaypipes): Add support for property and tag filters
 }
 
 func (f *ObjectListFilter) IsEmpty() bool {
-	return f.Partition == nil && f.ObjectType == nil && f.Project == "" && f.Search == ""
+	return f.Partition == nil && f.Type == nil && f.Project == "" && f.Search == ""
 }
 
 func (f *ObjectListFilter) String() string {
@@ -53,8 +53,8 @@ func (f *ObjectListFilter) String() string {
 	if f.Partition != nil {
 		attrMap["partition"] = f.Partition.Uuid
 	}
-	if f.ObjectType != nil {
-		attrMap["object_type"] = f.ObjectType.Code
+	if f.Type != nil {
+		attrMap["object_type"] = f.Type.Code
 	}
 	if f.Project != "" {
 		attrMap["project"] = f.Project
@@ -79,12 +79,12 @@ func (f *ObjectListFilter) String() string {
 // project-scoped or not, the object's name index will contain the object's
 // project along with the object type and name.
 func (s *Store) objectByNameIndexKey(obj *pb.Object) (string, error) {
-	objType, err := s.ObjectTypeGet(obj.ObjectType)
+	objType, err := s.ObjectTypeGet(obj.Type)
 	if err != nil {
 		s.log.ERR(
 			"storage.ObjectDelete: object type '%s' for object with "+
 				"UUID '%s' was not valid: %s",
-			obj.ObjectType, obj.Uuid, err,
+			obj.Type, obj.Uuid, err,
 		)
 		return "", errors.ErrUnknown
 	}
@@ -212,8 +212,8 @@ func (s *Store) objectsGetByFilter(
 					return nil, errors.ErrNotFound
 				}
 			}
-			if filter.ObjectType != nil {
-				if obj.ObjectType != filter.ObjectType.Code {
+			if filter.Type != nil {
+				if obj.Type != filter.Type.Code {
 					return nil, errors.ErrNotFound
 				}
 			}
@@ -236,8 +236,8 @@ func (s *Store) objectsGetByFilter(
 			// scan on all objects by the primary objects/by-uuid/ index and
 			// manually check to see if the deserialized Object's name has the
 			// requested name...
-			if filter.ObjectType != nil && filter.Partition != nil {
-				if filter.ObjectType.Scope == pb.ObjectTypeScope_PROJECT {
+			if filter.Type != nil && filter.Partition != nil {
+				if filter.Type.Scope == pb.ObjectTypeScope_PROJECT {
 					if filter.Project != "" {
 						// Just drop through if we don't have a project because
 						// we won't be able to look up a project-scoped object
@@ -246,7 +246,7 @@ func (s *Store) objectsGetByFilter(
 						// this filter
 						return s.objectsGetByProjectNameIndex(
 							filter.Partition.Uuid,
-							filter.ObjectType.Code,
+							filter.Type.Code,
 							filter.Project,
 							filter.Search,
 							filter.UsePrefix,
@@ -255,7 +255,7 @@ func (s *Store) objectsGetByFilter(
 				} else {
 					return s.objectsGetByNameIndex(
 						filter.Partition.Uuid,
-						filter.ObjectType.Code,
+						filter.Type.Code,
 						filter.Search,
 						filter.UsePrefix,
 					)
@@ -286,8 +286,8 @@ func (s *Store) objectsGetByFilter(
 				continue
 			}
 		}
-		if filter.ObjectType != nil {
-			if obj.ObjectType != filter.ObjectType.Code {
+		if filter.Type != nil {
+			if obj.Type != filter.Type.Code {
 				continue
 			}
 		}

--- a/pkg/metadata/types/README.md
+++ b/pkg/metadata/types/README.md
@@ -1,0 +1,2 @@
+The `pkg/metadata/types` package contains concrete structs used internally to
+the `runm-metadata` server and its storage layer.

--- a/pkg/metadata/types/object.go
+++ b/pkg/metadata/types/object.go
@@ -53,3 +53,15 @@ func (f *ObjectListFilter) String() string {
 	}
 	return fmt.Sprintf("ObjectListFilter(%s)", attrs)
 }
+
+// ObjectWithReferences is a concrete struct containing pointers to
+// already-constructed and validated Partition and ObjectType messages. This is
+// the struct that is passed to backend storage when creating new objects, not
+// the protobuffer Object message or the api/types/Object struct, neither of
+// which are guaranteed to be pre-validated and their relations already
+// expanded.
+type ObjectWithReferences struct {
+	Object    *pb.Object
+	Partition *pb.Partition
+	Type      *pb.ObjectType
+}

--- a/pkg/metadata/types/object.go
+++ b/pkg/metadata/types/object.go
@@ -1,0 +1,55 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+
+	pb "github.com/runmachine-io/runmachine/proto"
+)
+
+// A specialized filter class that has already looked up specific partition and
+// object types (expanded from user-supplied partition and type filter
+// strings). Users pass pb.ObjectFilter messages which contain optional
+// pb.PartitionFilter and pb.ObjectTypeFilter messages. Those may be expanded
+// (due to UsePrefix = true) to a set of partition UUIDs and/or object type
+// codes. We then create zero or more of these ObjectListFilter structs
+// that represent a specific filter on partition UUID and object type, along
+// with the the object's name/UUID and UsePrefix flag.
+type ObjectListFilter struct {
+	Partition *pb.Partition
+	Type      *pb.ObjectType
+	Project   string
+	Search    string
+	UsePrefix bool
+	// TODO(jaypipes): Add support for property and tag filters
+}
+
+func (f *ObjectListFilter) IsEmpty() bool {
+	return f.Partition == nil && f.Type == nil && f.Project == "" && f.Search == ""
+}
+
+func (f *ObjectListFilter) String() string {
+	attrMap := make(map[string]string, 0)
+	if f.Partition != nil {
+		attrMap["partition"] = f.Partition.Uuid
+	}
+	if f.Type != nil {
+		attrMap["object_type"] = f.Type.Code
+	}
+	if f.Project != "" {
+		attrMap["project"] = f.Project
+	}
+	if f.Search != "" {
+		attrMap["search"] = f.Search
+		attrMap["use_prefix"] = strconv.FormatBool(f.UsePrefix)
+	}
+	attrs := ""
+	x := 0
+	for k, v := range attrMap {
+		if x > 0 {
+			attrs += ","
+		}
+		attrs += k + "=" + v
+	}
+	return fmt.Sprintf("ObjectListFilter(%s)", attrs)
+}

--- a/proto/defs/object.proto
+++ b/proto/defs/object.proto
@@ -27,7 +27,7 @@ message Object {
     // The UUID of the partition this object is in
     string partition = 1;
     // The object type code this object is
-    string object_type = 2;
+    string type = 2;
     // The external identifier of the project this object is owned by. Can be
     // empty if the type of object isn't ownable by a project (for instance, a
     // `runm.provider` isn't ownable by a project, but a `runm.machine` is)
@@ -46,7 +46,7 @@ message Object {
 // Used in matching object records
 message ObjectFilter {
     PartitionFilter partition = 1;
-    ObjectTypeFilter object_type = 2;
+    ObjectTypeFilter type = 2;
     // The project the object must belong to, if the object type scope of this
     // object is PROJECT
     string project = 3;

--- a/proto/defs/service_metadata.proto
+++ b/proto/defs/service_metadata.proto
@@ -11,6 +11,11 @@ import "search.proto";
 import "session.proto";
 import "wrappers.proto";
 
+enum PayloadFormat {
+    YAML = 0;
+    PROTOBUFFER = 1;
+}
+
 // The runm-metadata gRPC service is a lookup service for UUID to external
 // unique names.
 //
@@ -131,11 +136,10 @@ message ObjectSetFields {
 
 message ObjectSetRequest {
     Session session = 1;
-    // The before image of the object to change. Empty if the caller expects
-    // they are creating a new object
-    Object before = 2;
-    // The new image of the object being changed or created.
-    Object after = 3;
+    PayloadFormat format = 2;
+    // Raw bytes representing the new representation of the object. The server
+    // is responsible for unmarshaling this raw payload.
+    bytes payload = 3;
 }
 
 message ObjectSetResponse {


### PR DESCRIPTION
Major changes in this patch set:
* Handle YAML unmarshaling on server side, not runm client
* Introduce concrete internal types in metadata service
* Remove cursor interface from object listing operations
* Clean up the way that partition and object types are referenced in ObjectDelete

Issue #43