### PR TITLE
Add PropertySchemaDocument api type

### DIFF
--- a/pkg/api/types/property.go
+++ b/pkg/api/types/property.go
@@ -42,10 +42,10 @@ type PropertySchemaDocument struct {
 	Enum []string `yaml:"enum"`
 	// Indicates the property is required for all objects of this property
 	// schema's object type
-	Required bool `yaml:"required"`
+	Required *bool `yaml:"required"`
 	// Indicates the property's value must be a multiple of this number. The
 	// property's type must be either "number" or "integer"
-	MultipleOf uint `yaml:"multiple_of"`
+	MultipleOf *uint `yaml:"multiple_of"`
 	// Indicates the property's numeric value must be greater than or equal to
 	// this number The property's type must be either "number" or "integer"
 	Minimum *int `yaml:"minimum"`
@@ -54,10 +54,10 @@ type PropertySchemaDocument struct {
 	Maximum *int `yaml:"maximum"`
 	// Indicates the property's value must be a string and that string must
 	// have a length greater than or equal to this number
-	MinLength uint `yaml:"min_length"`
+	MinLength *uint `yaml:"min_length"`
 	// Indicates the property's value must be a string and that string must
 	// have a length less than or equal to this number
-	MaxLength uint `yaml:"max_length"`
+	MaxLength *uint `yaml:"max_length"`
 	// Indicates the property's value must be a string and must match this
 	// regex pattern
 	Pattern string `yaml:"pattern"`

--- a/pkg/api/types/property.go
+++ b/pkg/api/types/property.go
@@ -42,7 +42,7 @@ type PropertySchemaDocument struct {
 	Enum []string `yaml:"enum"`
 	// Indicates the property is required for all objects of this property
 	// schema's object type
-	Required *bool `yaml:"required"`
+	Required bool `yaml:"required"`
 	// Indicates the property's value must be a multiple of this number. The
 	// property's type must be either "number" or "integer"
 	MultipleOf *uint `yaml:"multiple_of"`

--- a/pkg/api/types/property.go
+++ b/pkg/api/types/property.go
@@ -7,7 +7,76 @@ type PropertySchema struct {
 	Type string `yaml:"type"`
 	// The key of the property this schema will apply to
 	Key string `yaml:"key"`
-	// JSONSchema document represented in YAML, dictating the constraints
-	// applied by this schema to the property's value
+	// JSONSchema property type document represented in YAML, dictating the
+	// constraints applied by this schema to the property's value
 	Schema string `yaml:"schema"`
+}
+
+// NOTE(jaypipes): A type that can be represented in YAML as *either* a string
+// *or* an array of strings, which is what JSONSchema's type field needs.
+// see: https://github.com/go-yaml/yaml/issues/100
+type StringArray []string
+
+func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var multi []string
+	err := unmarshal(&multi)
+	if err != nil {
+		var single string
+		err := unmarshal(&single)
+		if err != nil {
+			return err
+		}
+		*a = []string{single}
+	} else {
+		*a = multi
+	}
+	return nil
+}
+
+type PropertySchemaDocument struct {
+	// May only be a JSON scalar type (string, integer, number, etc)
+	Types StringArray `yaml:"type"`
+	// Property value must be one of these enumerated list of values. If this
+	// exists in the schema document and no types are specified, type is
+	// assumed to be string
+	Enum []string `yaml:"enum"`
+	// Indicates the property is required for all objects of this property
+	// schema's object type
+	Required bool `yaml:"required"`
+	// Indicates the property's value must be a multiple of this number. The
+	// property's type must be either "number" or "integer"
+	MultipleOf uint `yaml:"multiple_of"`
+	// Indicates the property's numeric value must be greater than or equal to
+	// this number The property's type must be either "number" or "integer"
+	Minimum *int `yaml:"minimum"`
+	// Indicates the property's numeric value must be less than or equal to
+	// this number The property's type must be either "number" or "integer"
+	Maximum *int `yaml:"maximum"`
+	// Indicates the property's value must be a string and that string must
+	// have a length greater than or equal to this number
+	MinLength uint `yaml:"min_length"`
+	// Indicates the property's value must be a string and that string must
+	// have a length less than or equal to this number
+	MaxLength uint `yaml:"max_length"`
+	// Indicates the property's value must be a string and must match this
+	// regex pattern
+	Pattern string `yaml:"pattern"`
+	// A pre-defined regex that will validate the incoming property value.
+	// Possible string values for "format" are:
+	//
+	// * "date-time"
+	// * "date"
+	// * "time"
+	// * "email"
+	// * "idn-email"
+	// * "hostname"
+	// * "idn-hostname"
+	// * "ipv4"
+	// * "ipv6"
+	// * "uri"
+	// * "uri-reference"
+	// * "iri"
+	// * "iri-reference"
+	// * "uri-template"
+	Format string `yaml:"format"`
 }

--- a/pkg/api/types/property_test.go
+++ b/pkg/api/types/property_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 var (
-	_true    = true
 	_zero    = 0
 	_one     = 1
 	_two     = 2
@@ -92,7 +91,7 @@ min_length: 0
 required: true
 `,
 			expect: types.PropertySchemaDocument{
-				Required: &_true,
+				Required: true,
 			},
 		},
 	}

--- a/pkg/api/types/property_test.go
+++ b/pkg/api/types/property_test.go
@@ -10,7 +10,13 @@ import (
 )
 
 var (
-	_one = 1
+	_true    = true
+	_zero    = 0
+	_one     = 1
+	_two     = 2
+	_zero_us = uint(0)
+	_one_us  = uint(1)
+	_two_us  = uint(2)
 )
 
 func TestPropertySchemaDocumentYAML(t *testing.T) {
@@ -44,13 +50,49 @@ type:
 				},
 			},
 		},
-		// Simple single string type
+		// Check maximum (number-based)
 		{
 			doc: `
 maximum: 1
 `,
 			expect: types.PropertySchemaDocument{
 				Maximum: &_one,
+			},
+		},
+		// Check minimum (number-based)
+		{
+			doc: `
+minimum: 0
+`,
+			expect: types.PropertySchemaDocument{
+				Minimum: &_zero,
+			},
+		},
+		// Check nax length (string)
+		{
+			doc: `
+max_length: 2
+`,
+			expect: types.PropertySchemaDocument{
+				MaxLength: &_two_us,
+			},
+		},
+		// Check min length (string)
+		{
+			doc: `
+min_length: 0
+`,
+			expect: types.PropertySchemaDocument{
+				MinLength: &_zero_us,
+			},
+		},
+		// Check required
+		{
+			doc: `
+required: true
+`,
+			expect: types.PropertySchemaDocument{
+				Required: &_true,
 			},
 		},
 	}

--- a/pkg/api/types/property_test.go
+++ b/pkg/api/types/property_test.go
@@ -1,0 +1,65 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/runmachine-io/runmachine/pkg/api/types"
+)
+
+var (
+	_one = 1
+)
+
+func TestPropertySchemaDocumentYAML(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		doc    string
+		expect types.PropertySchemaDocument
+	}{
+		// Simple single string type
+		{
+			doc: `
+type: string
+`,
+			expect: types.PropertySchemaDocument{
+				Types: []string{
+					"string",
+				},
+			},
+		},
+		// Array of multiple type strings
+		{
+			doc: `
+type:
+  - string
+  - integer
+`,
+			expect: types.PropertySchemaDocument{
+				Types: []string{
+					"string", "integer",
+				},
+			},
+		},
+		// Simple single string type
+		{
+			doc: `
+maximum: 1
+`,
+			expect: types.PropertySchemaDocument{
+				Maximum: &_one,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		got := types.PropertySchemaDocument{}
+		if err := yaml.Unmarshal([]byte(test.doc), &got); err != nil {
+			t.Fatalf("failed unmarshalling %s: %v", test.doc, err)
+		}
+		assert.Equal(test.expect, got)
+	}
+}


### PR DESCRIPTION
Adds a new API type called PropertySchemaDocument that represents the
actual schema document we'll use for property validation. The property
schema document is essentially a stripped-down JSONSchema property type
partial document describing the constraints and format of the property
value being validated.

The numeric fields such as `MaxLength`, `MultipleOf`, etc are pointers to `int` or
`uint` because there is no way to differentiate between a user setting the value of
these fields to 0 and the zero-value of the field in the `PropertySchemaDocument`
struct itself.