### PR TITLE
add access permission handling to prop definitions

### DIFF
--- a/cmd/runm/commands/property_definition.go
+++ b/cmd/runm/commands/property_definition.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	apitypes "github.com/runmachine-io/runmachine/pkg/api/types"
 	pb "github.com/runmachine-io/runmachine/proto"
 	"github.com/spf13/cobra"
 )
@@ -25,5 +26,38 @@ func printPropertyDefinition(obj *pb.PropertyDefinition) {
 	fmt.Printf("Type:         %s\n", obj.Type)
 	fmt.Printf("Key:          %s\n", obj.Key)
 	fmt.Printf("Required:     %s\n", strconv.FormatBool(obj.IsRequired))
+	if len(obj.Permissions) > 0 {
+		fmt.Printf("Permissions:\n")
+		for x, perm := range obj.Permissions {
+			permStr := ""
+			if perm.Project != nil {
+				permStr += "project: " + perm.Project.Value
+			}
+			if perm.Role != nil {
+				if len(permStr) > 0 {
+					permStr += " "
+				}
+				permStr += "role: " + perm.Role.Value
+			}
+			if len(permStr) > 0 {
+				permStr += " "
+			}
+			permStr += "permission: "
+			readBit := perm.Permission & apitypes.PERMISSION_READ
+			writeBit := perm.Permission & apitypes.PERMISSION_WRITE
+			if readBit == apitypes.PERMISSION_READ {
+				if writeBit == apitypes.PERMISSION_WRITE {
+					permStr += "READ/WRITE"
+				} else {
+					permStr += "READ"
+				}
+			} else if writeBit == apitypes.PERMISSION_WRITE {
+				permStr += "WRITE"
+			} else {
+				permStr += "NONE (Deny)"
+			}
+			fmt.Printf("  %d: %s\n", x+1, permStr)
+		}
+	}
 	fmt.Printf("Schema:\n%s", obj.Schema)
 }

--- a/pkg/api/types/property_definition.go
+++ b/pkg/api/types/property_definition.go
@@ -4,6 +4,12 @@ import (
 	"fmt"
 )
 
+const (
+	PERMISSION_NONE  = uint32(0)
+	PERMISSION_READ  = uint32(1)
+	PERMISSION_WRITE = uint32(1) << 1
+)
+
 var (
 	// the set of valid type strings that may appear in the property schema
 	// document "type" field
@@ -33,6 +39,23 @@ var (
 	}
 )
 
+// PropertyPermission describes the permission that a project and/or role have
+// to read or write a property on an object
+type PropertyPermission struct {
+	// Optional project identifier to control access for
+	Project string `yaml:"project"`
+	// Optional role identifier to control access for
+	Role string `yaml:"role"`
+	// A string containing the permissions:
+	//
+	// "" indicates the project/role should have no read or write access to the
+	// property
+	// "r" indicates the project/role should have read access
+	// "w" indicates the project/role should have write access
+	// "rw" indicates the project/role should have read and write access
+	Permission string `yaml:"permission"`
+}
+
 type PropertyDefinition struct {
 	// Identifier of the partition the object belongs to
 	Partition string `yaml:"partition"`
@@ -45,7 +68,8 @@ type PropertyDefinition struct {
 	Schema *PropertySchema `yaml:"schema"`
 	// Indicates the property is required for all objects of this object type
 	Required bool `yaml:"required"`
-	// TODO(jaypipes): Add access permissions
+	// Set of project/role specific permissions for the property
+	Permissions []*PropertyPermission `yaml:"permissions"`
 }
 
 // NOTE(jaypipes): A type that can be represented in YAML as *either* a string

--- a/pkg/api/types/property_definition_test.go
+++ b/pkg/api/types/property_definition_test.go
@@ -18,6 +18,147 @@ var (
 	_two_us  = uint(2)
 )
 
+func TestPropertyDefinitionYAML(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		doc    string
+		expect types.PropertyDefinition
+	}{
+		// Required missing
+		{
+			doc: `
+type: runm.image
+key: architecture
+`,
+			expect: types.PropertyDefinition{
+				Type:     "runm.image",
+				Key:      "architecture",
+				Required: false,
+			},
+		},
+		// Required false
+		{
+			doc: `
+type: runm.image
+key: architecture
+required: false
+`,
+			expect: types.PropertyDefinition{
+				Type:     "runm.image",
+				Key:      "architecture",
+				Required: false,
+			},
+		},
+		// Required true
+		{
+			doc: `
+type: runm.image
+key: architecture
+required: true
+`,
+			expect: types.PropertyDefinition{
+				Type:     "runm.image",
+				Key:      "architecture",
+				Required: true,
+			},
+		},
+		// Project access permission specified
+		{
+			doc: `
+type: runm.image
+key: architecture
+permissions:
+  - project: proj1
+    permission: rw
+`,
+			expect: types.PropertyDefinition{
+				Type: "runm.image",
+				Key:  "architecture",
+				Permissions: []*types.PropertyPermission{
+					&types.PropertyPermission{
+						Project:    "proj1",
+						Permission: "rw",
+					},
+				},
+			},
+		},
+		// Role access permission specified
+		{
+			doc: `
+type: runm.image
+key: architecture
+permissions:
+  - role: admin
+    permission: rw
+`,
+			expect: types.PropertyDefinition{
+				Type: "runm.image",
+				Key:  "architecture",
+				Permissions: []*types.PropertyPermission{
+					&types.PropertyPermission{
+						Role:       "admin",
+						Permission: "rw",
+					},
+				},
+			},
+		},
+		// Project and role access permission specified
+		{
+			doc: `
+type: runm.image
+key: architecture
+permissions:
+  - role: member
+    project: proj2
+    permission: r
+`,
+			expect: types.PropertyDefinition{
+				Type: "runm.image",
+				Key:  "architecture",
+				Permissions: []*types.PropertyPermission{
+					&types.PropertyPermission{
+						Role:       "member",
+						Project:    "proj2",
+						Permission: "r",
+					},
+				},
+			},
+		},
+		// Permission with blank permission string (used for revoking all
+		// permissions on a property)
+		{
+			doc: `
+type: runm.image
+key: architecture
+permissions:
+  - role: member
+    project: blacklisted
+    permission:
+`,
+			expect: types.PropertyDefinition{
+				Type: "runm.image",
+				Key:  "architecture",
+				Permissions: []*types.PropertyPermission{
+					&types.PropertyPermission{
+						Role:       "member",
+						Project:    "blacklisted",
+						Permission: "",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		got := types.PropertyDefinition{}
+		if err := yaml.Unmarshal([]byte(test.doc), &got); err != nil {
+			t.Fatalf("failed unmarshalling %s: %v", test.doc, err)
+		}
+		assert.Equal(test.expect, got)
+	}
+}
+
 func TestPropertySchemaYAML(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/metadata/property_definition.go
+++ b/pkg/metadata/property_definition.go
@@ -201,11 +201,12 @@ func (s *Server) validatePropertyDefinitionSetRequest(
 		Partition: part,
 		Type:      objType,
 		Definition: &pb.PropertyDefinition{
-			Partition:  part.Uuid,
-			Type:       objType.Code,
-			Key:        obj.Key,
-			IsRequired: obj.Required,
-			Schema:     obj.Schema.JSONSchemaString(),
+			Partition:   part.Uuid,
+			Type:        objType.Code,
+			Key:         obj.Key,
+			IsRequired:  obj.Required,
+			Permissions: types.APItoPBPropertyPermissions(obj.Permissions),
+			Schema:      obj.Schema.JSONSchemaString(),
 		},
 	}, nil
 }
@@ -258,13 +259,14 @@ func (s *Server) PropertyDefinitionSet(
 
 		// Set default access permissions to read/write by any role in the
 		// creating project
-		if def.AccessPermissions == nil {
-			def.AccessPermissions = []*pb.PropertyAccessPermission{
-				&pb.PropertyAccessPermission{
+		if def.Permissions == nil {
+			rwPerm := apitypes.PERMISSION_READ | apitypes.PERMISSION_WRITE
+			def.Permissions = []*pb.PropertyPermission{
+				&pb.PropertyPermission{
 					Project: &pb.StringValue{
 						Value: req.Session.Project,
 					},
-					Permission: pb.AccessPermission_READ_WRITE,
+					Permission: rwPerm,
 				},
 			}
 		}

--- a/pkg/metadata/types/property_definition.go
+++ b/pkg/metadata/types/property_definition.go
@@ -155,3 +155,41 @@ func TranslatePropertySchema(as *apitypes.PropertySchema) *pb.PropertySchema {
 	}
 	return res
 }
+
+// APItoPBPropertyPermissions converts the apitypes.PropertyPermissions to
+// protobuffer PropertyPermissions that get stored in backend storage
+func APItoPBPropertyPermissions(
+	apiperms []*apitypes.PropertyPermission,
+) []*pb.PropertyPermission {
+	res := make([]*pb.PropertyPermission, len(apiperms))
+	for x, apiperm := range apiperms {
+		// Convert the string "r", "rw" representation to the integer
+		// permission code used in backend protobuffer storage
+		iperm := apitypes.PERMISSION_NONE
+		switch apiperm.Permission {
+		case "r":
+			iperm = apitypes.PERMISSION_READ
+		case "rw":
+			iperm = apitypes.PERMISSION_READ | apitypes.PERMISSION_WRITE
+		case "w":
+			iperm = apitypes.PERMISSION_WRITE
+		default:
+			iperm = apitypes.PERMISSION_NONE
+		}
+		pbperm := &pb.PropertyPermission{
+			Permission: iperm,
+		}
+		if apiperm.Project != "" {
+			pbperm.Project = &pb.StringValue{
+				Value: apiperm.Project,
+			}
+		}
+		if apiperm.Role != "" {
+			pbperm.Role = &pb.StringValue{
+				Value: apiperm.Role,
+			}
+		}
+		res[x] = pbperm
+	}
+	return res
+}

--- a/proto/defs/permission.proto
+++ b/proto/defs/permission.proto
@@ -25,11 +25,3 @@ enum Permission {
 message PermissionSet {
     repeated Permission permissions = 1;
 }
-
-// A special type of permission attached to things like metadata items
-enum AccessPermission {
-    NONE = 0;
-    READ = 1;
-    WRITE = 2;
-    READ_WRITE = 3;
-}

--- a/proto/defs/property.proto
+++ b/proto/defs/property.proto
@@ -14,10 +14,20 @@ message Property {
 
 // Indicates whether a particular property item may be changed or read by a
 // class of user
-message PropertyAccessPermission {
+message PropertyPermission {
     StringValue project = 1;
     StringValue role = 2;
-    AccessPermission permission = 3;
+    // The read/write permissions on the property. The default permissions for
+    // any property on an object is that if a user is allowed to read the
+    // object, the user is allowed to read all properties associated with the
+    // object. To deny read permission to a particular role or project, a
+    // PropertyAccessPermission can be created with a zero-valued permission
+    // field, which indicates the role and/or project cannot read the property.
+    //
+    // 0            No permissions  (used to deny rights to specific project)
+    // 1            Read permission
+    // 1 << 1       Write permission
+    uint32 permission = 3;
 }
 
 // Administrators are able to create schemas that allow the restriction of data
@@ -115,8 +125,8 @@ message PropertyDefinition {
     string schema = 4;
     // true if this property key must be set on objects of this type
     bool is_required = 5;
-    // Collection of access permissions applied to this property definition
-    repeated PropertyAccessPermission access_permissions = 50;
+    // Collection of access permissions applied to this property
+    repeated PropertyPermission permissions = 50;
 }
 
 // Used in matching property definition records

--- a/tests/data/property-definitions/runm.provider-location.site.yaml
+++ b/tests/data/property-definitions/runm.provider-location.site.yaml
@@ -1,0 +1,12 @@
+partition: part0
+type: runm.provider
+key: location.site
+required: true
+permissions:
+  # Default to not allowing reads from anyone
+  - permission:
+  # Unless the user is an admin
+  - role: admin
+    permission: rw
+schema:
+  type: string


### PR DESCRIPTION
When creating a property definition, the YAML now handles parsing of
property access permissions. `runm property-definition get` also now
shows access permissions defined for the property:

```
[jaypipes@uberbox runmachine]$ cat tests/data/property-definitions/runm.provider-location.site.yaml
partition: part0
type: runm.provider
key: location.site
required: true
permissions:
  # Default to not allowing reads from anyone
  - permission:
  # Unless the user is an admin
  - role: admin
    permission: rw
schema:
  type: string
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh property-definition get runm.provider location.site
Partition:    9320940e62794ff8a84baa1a0c11a9c5
Type:         runm.provider
Key:          location.site
Required:     true
Permissions:
  1: permission: NONE (Deny)
  2: role: admin permission: READ/WRITE
Schema:
type: string
```

Issue #21