### PR TITLE
enhancements to PropertyDefinitionSet

### DIFF
--- a/cmd/runm/commands/property_definition.go
+++ b/cmd/runm/commands/property_definition.go
@@ -45,13 +45,13 @@ func printPropertyDefinition(obj *pb.PropertyDefinition) {
 			permStr += "permission: "
 			readBit := perm.Permission & apitypes.PERMISSION_READ
 			writeBit := perm.Permission & apitypes.PERMISSION_WRITE
-			if readBit == apitypes.PERMISSION_READ {
-				if writeBit == apitypes.PERMISSION_WRITE {
+			if readBit != 0 {
+				if writeBit != 0 {
 					permStr += "READ/WRITE"
 				} else {
 					permStr += "READ"
 				}
-			} else if writeBit == apitypes.PERMISSION_WRITE {
+			} else if writeBit != 0 {
 				permStr += "WRITE"
 			} else {
 				permStr += "NONE (Deny)"

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -52,7 +52,7 @@ func ErrObjectTypeNotFound(objType string) *Error {
 		HTTPCode: 404,
 		Code:     404001,
 		Message: fmt.Sprintf(
-			"object type %s could not be found.",
+			"object type '%s' could not be found.",
 			objType,
 		),
 	}
@@ -63,7 +63,7 @@ func ErrPartitionNotFound(partition string) *Error {
 		HTTPCode: 404,
 		Code:     404002,
 		Message: fmt.Sprintf(
-			"partition %s could not be found.",
+			"partition '%s' could not be found.",
 			partition,
 		),
 	}
@@ -74,19 +74,24 @@ func ErrFailedPropertyDefinitionValidation(key string, err error) *Error {
 		HTTPCode: 400,
 		Code:     400001,
 		Message: fmt.Sprintf(
-			"property with key %s failed schema validation: %s.",
+			"property with key '%s' failed schema validation: %s.",
 			key,
 			err,
 		),
 	}
 }
 
-func ErrInvalidPropertyDefinition(objType string, key string, err error) *Error {
+func ErrInvalidPropertyDefinition(
+	objType string,
+	key string,
+	err error,
+) *Error {
 	return &Error{
 		HTTPCode: 400,
 		Code:     400002,
 		Message: fmt.Sprintf(
-			"invalid property definition for object type %s and key %s: %s.",
+			"invalid property definition for object type '%s' "+
+				"and key '%s': %s.",
 			objType,
 			key,
 			err,

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -210,10 +210,12 @@ func (s *Server) validateObjectProperty(
 	key string,
 	value string,
 ) (*pb.Property, error) {
-	propDef, err := s.store.PropertyDefinitionGet(
-		partition.Uuid,
-		objType.Code,
-		key,
+	propDef, err := s.store.PropertyDefinitionGetByPK(
+		&types.PropertyDefinitionPK{
+			Partition:   partition.Uuid,
+			ObjectType:  objType.Code,
+			PropertyKey: key,
+		},
 	)
 	if err != nil && err != errors.ErrNotFound {
 		return nil, err

--- a/pkg/metadata/types/property_definition.go
+++ b/pkg/metadata/types/property_definition.go
@@ -9,6 +9,18 @@ import (
 	pb "github.com/runmachine-io/runmachine/proto"
 )
 
+// A property definition is always uniquely identified by partition UUID,
+// object type code and property key
+type PropertyDefinitionPK struct {
+	Partition   string
+	ObjectType  string
+	PropertyKey string
+}
+
+func (pk *PropertyDefinitionPK) String() string {
+	return pk.Partition + ":" + pk.ObjectType + ":" + pk.PropertyKey
+}
+
 // A specialized filter class that has already looked up specific partition and
 // object types (expanded from user-supplied partition and type filter
 // strings). Users pass pb.PropertyDefinitionFilter messages which contain optional


### PR DESCRIPTION
Changes the storage.PropertyDefinitionGet and
storage.PropertyDefinitionDelete methods to take a new
metadatatypes.PropertyDefinitionPK struct that describes the primary key
for the property definition.

Adds validation for ensuring that default permissions are applied to
newly-created property definitions are writeable by anyone in the
project creating the definition.

Adds validation of the parsed permission structs that may optionally be
attached to a property definition.

Issue #21