### PR TITLE
fix object and prop-def get error return

### DIFF
--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -94,8 +94,10 @@ func (s *Server) ObjectGet(
 	if err != nil {
 		return nil, err
 	}
-	if len(objects) != 1 {
+	if len(objects) > 1 {
 		return nil, ErrMultipleRecordsFound
+	} else if len(objects) == 0 {
+		return nil, ErrNotFound
 	}
 
 	return objects[0], nil

--- a/pkg/metadata/object_filter.go
+++ b/pkg/metadata/object_filter.go
@@ -42,18 +42,19 @@ func (s *Server) expandObjectFilter(
 	filter *pb.ObjectFilter,
 ) ([]*types.ObjectListFilter, error) {
 	res := make([]*types.ObjectListFilter, 0)
+	var err error
 	// A set of partition UUIDs that we'll create types.ObjectListFilters with.
 	// These are the UUIDs of any partitions that match the PartitionFilter in
 	// the supplied pb.ObjectFilter
-	partitions := make([]*pb.Partition, 0)
+	var partitions []*pb.Partition
 	// A set of object type codes that we'll create types.ObjectListFilters
 	// with. These are the codes of object types that match the
 	// ObjectTypeFilter in the supplied ObjectFilter
-	objTypes := make([]*pb.ObjectType, 0)
+	var objTypes []*pb.ObjectType
 
 	if filter.Partition != nil {
 		// Verify that the requested partition(s) exist(s)
-		partitions, err := s.store.PartitionList([]*pb.PartitionFilter{filter.Partition})
+		partitions, err = s.store.PartitionList([]*pb.PartitionFilter{filter.Partition})
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +83,7 @@ func (s *Server) expandObjectFilter(
 
 	if filter.Type != nil {
 		// Verify that the object type even exists
-		objTypes, err := s.store.ObjectTypeList([]*pb.ObjectTypeFilter{filter.Type})
+		objTypes, err = s.store.ObjectTypeList([]*pb.ObjectTypeFilter{filter.Type})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/metadata/property_definition.go
+++ b/pkg/metadata/property_definition.go
@@ -105,8 +105,10 @@ func (s *Server) PropertyDefinitionGet(
 	if err != nil {
 		return nil, err
 	}
-	if len(objects) != 1 {
+	if len(objects) > 1 {
 		return nil, ErrMultipleRecordsFound
+	} else if len(objects) == 0 {
+		return nil, ErrNotFound
 	}
 
 	return objects[0], nil

--- a/pkg/metadata/property_definition_filter.go
+++ b/pkg/metadata/property_definition_filter.go
@@ -31,28 +31,34 @@ func (s *Server) defaultPropertyDefinitionFilter(
 	}, nil
 }
 
-// expandPropertyDefinitionFilter is used to expand an PropertyDefinitionFilter, which may contain
-// PartitionFilter and ObjectTypeFilter objects that themselves may resolve to
-// multiple partitions or object types, to a set of types.PropertyDefinitionFilter
-// objects. A types.PropertyDefinitionFilter is used to describe a filter on objects in
-// a *specific* partition and having a *specific* object type.
+// expandPropertyDefinitionFilter is used to expand an
+// PropertyDefinitionFilter, which may contain PartitionFilter and
+// ObjectTypeFilter objects that themselves may resolve to multiple partitions
+// or object types, to a set of types.PropertyDefinitionFilter objects. A
+// types.PropertyDefinitionFilter is used to describe a filter on objects in a
+// *specific* partition and having a *specific* object type.
 func (s *Server) expandPropertyDefinitionFilter(
 	session *pb.Session,
 	filter *pb.PropertyDefinitionFilter,
 ) ([]*types.PropertyDefinitionFilter, error) {
 	res := make([]*types.PropertyDefinitionFilter, 0)
-	// A set of partition UUIDs that we'll create types.PropertyDefinitionFilters with.
-	// These are the UUIDs of any partitions that match the PartitionFilter in
-	// the supplied pb.PropertyDefinitionFilter
-	partitions := make([]*pb.Partition, 0)
-	// A set of object type codes that we'll create types.PropertyDefinitionFilters
-	// with. These are the codes of object types that match the
-	// ObjectTypeFilter in the supplied PropertyDefinitionFilter
-	objTypes := make([]*pb.ObjectType, 0)
+	var err error
+	// A set of partition UUIDs that we'll create
+	// types.PropertyDefinitionFilters with.  These are the UUIDs of any
+	// partitions that match the PartitionFilter in the supplied
+	// pb.PropertyDefinitionFilter
+	var partitions []*pb.Partition
+	// A set of object type codes that we'll create
+	// types.PropertyDefinitionFilters with. These are the codes of object
+	// types that match the ObjectTypeFilter in the supplied
+	// PropertyDefinitionFilter
+	var objTypes []*pb.ObjectType
 
 	if filter.Partition != nil {
 		// Verify that the requested partition(s) exist(s)
-		partitions, err := s.store.PartitionList([]*pb.PartitionFilter{filter.Partition})
+		partitions, err = s.store.PartitionList(
+			[]*pb.PartitionFilter{filter.Partition},
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -81,7 +87,9 @@ func (s *Server) expandPropertyDefinitionFilter(
 
 	if filter.Type != nil {
 		// Verify that the object type even exists
-		objTypes, err := s.store.ObjectTypeList([]*pb.ObjectTypeFilter{filter.Type})
+		objTypes, err = s.store.ObjectTypeList(
+			[]*pb.ObjectTypeFilter{filter.Type},
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
There were two bugs in the property-definition and object get
implementations that were leading to an improper error about multiple
matching records being returned instead of the expected not found error.

The first issue was due to incorrect ObjectListFilter or
PropertyDefinitionFilter structs being produced from the
expandPropertyDefinitionFilter() method. This was due to
improperly-shadowed variables used to create the partitions and object
types lists used in creating the filter structs. The fix for this was to
declare the err, partitions and objTypes variables at the top of the
expandPropertyDefinitionFilter() method instead of using Golang's
automatic := variable instantiation. This is definitely not the first
time I've been bitten by Golang's awkward duplicity in how variables can
be instantiated (auto versus declared)...

The second issue was due to a silly logical error in the ObjectGet and
PropertyDefinitionGet gRPC API service method implementations that was
checking for len(objects) != 1 and always returning
ErrMultipleRecordsFound. Simply changing this to >1 and adding in a
check for len(objects) == 0 to return ErrNotFound fixed this particular
problem.

Fixes Issue #75