### PR TITLE
store schema as PropertySchema PB message

### DIFF
--- a/cmd/runm/commands/property_definition.go
+++ b/cmd/runm/commands/property_definition.go
@@ -9,6 +9,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	propSchemaFormatMap = map[pb.PropertySchema_Format]string{
+		pb.PropertySchema_FORMAT_DATETIME:      "date-time",
+		pb.PropertySchema_FORMAT_DATE:          "date",
+		pb.PropertySchema_FORMAT_TIME:          "time",
+		pb.PropertySchema_FORMAT_EMAIL:         "email",
+		pb.PropertySchema_FORMAT_IDN_EMAIL:     "idn-email",
+		pb.PropertySchema_FORMAT_HOSTNAME:      "hostname",
+		pb.PropertySchema_FORMAT_IDN_HOSTNAME:  "idn-hostname",
+		pb.PropertySchema_FORMAT_IPV4:          "ipv4",
+		pb.PropertySchema_FORMAT_IPV6:          "ipv6",
+		pb.PropertySchema_FORMAT_URI:           "uri",
+		pb.PropertySchema_FORMAT_URI_REFERENCE: "uri-reference",
+		pb.PropertySchema_FORMAT_IRI:           "iri",
+		pb.PropertySchema_FORMAT_IRI_REFERENCE: "iri-reference",
+		pb.PropertySchema_FORMAT_URI_TEMPLATE:  "uri-template",
+	}
+	propSchemaTypeMap = map[pb.PropertySchema_Type]string{
+		pb.PropertySchema_TYPE_STRING:  "string",
+		pb.PropertySchema_TYPE_INTEGER: "integer",
+		pb.PropertySchema_TYPE_NUMBER:  "number",
+		pb.PropertySchema_TYPE_BOOLEAN: "boolean",
+	}
+)
+
 var propertyDefinitionCommand = &cobra.Command{
 	Use:   "property-definition",
 	Short: "Manipulate property definition information",
@@ -19,6 +44,35 @@ func init() {
 	propertyDefinitionCommand.AddCommand(propertyDefinitionGetCommand)
 	propertyDefinitionCommand.AddCommand(propertyDefinitionSetCommand)
 	propertyDefinitionCommand.AddCommand(propertyDefinitionDeleteCommand)
+}
+
+func printPropertySchema(obj *pb.PropertySchema) {
+	fmt.Printf("Schema:\n")
+	fmt.Printf("  Types:\n")
+	for _, t := range obj.Types {
+		fmt.Printf("    - %s\n", propSchemaTypeMap[t])
+	}
+	if obj.MultipleOf != nil {
+		fmt.Printf("  Multiple of: %d\n", obj.MultipleOf.Value)
+	}
+	if obj.Minimum != nil {
+		fmt.Printf("  Minimum: %d\n", obj.Minimum.Value)
+	}
+	if obj.Maximum != nil {
+		fmt.Printf("  Maximum: %d\n", obj.Maximum.Value)
+	}
+	if obj.MinimumLength != nil {
+		fmt.Printf("  Minimum length: %d\n", obj.MinimumLength.Value)
+	}
+	if obj.MaximumLength != nil {
+		fmt.Printf("  Maximum length: %d\n", obj.MaximumLength.Value)
+	}
+	if obj.Format != pb.PropertySchema_FORMAT_NONE {
+		fmt.Printf("  Format: %s\n", propSchemaFormatMap[obj.Format])
+	}
+	if obj.Pattern != "" {
+		fmt.Printf("  Pattern: %s", obj.Pattern)
+	}
 }
 
 func printPropertyDefinition(obj *pb.PropertyDefinition) {
@@ -59,5 +113,7 @@ func printPropertyDefinition(obj *pb.PropertyDefinition) {
 			fmt.Printf("  %d: %s\n", x+1, permStr)
 		}
 	}
-	fmt.Printf("Schema:\n%s", obj.Schema)
+	if obj.Schema != nil {
+		printPropertySchema(obj.Schema)
+	}
 }

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -236,7 +236,10 @@ func (s *Server) validateObjectProperty(
 
 // validateValueWithSchema returns an error if the supplied value passes the
 // supplied property meta document, nil otherwise.
-func (s *Server) validateValueWithSchema(value string, schema string) error {
+func (s *Server) validateValueWithSchema(
+	value string,
+	schema *pb.PropertySchema,
+) error {
 	return nil
 }
 

--- a/pkg/metadata/property_definition.go
+++ b/pkg/metadata/property_definition.go
@@ -194,7 +194,7 @@ func (s *Server) validatePropertyDefinitionSetRequest(
 			Key:         def.Key,
 			IsRequired:  def.Required,
 			Permissions: types.APItoPBPropertyPermissions(def.Permissions),
-			Schema:      def.Schema.JSONSchemaString(),
+			Schema:      types.APItoPBPropertySchema(def.Schema),
 		},
 	}, nil
 }

--- a/pkg/metadata/types/property_definition.go
+++ b/pkg/metadata/types/property_definition.go
@@ -75,9 +75,9 @@ type PropertyDefinitionWithReferences struct {
 	Definition *pb.PropertyDefinition
 }
 
-// Converts an apitypes PropertySchema to the protobuffer PropertySchema
-// message that will eb stored in backend storage
-func TranslatePropertySchema(as *apitypes.PropertySchema) *pb.PropertySchema {
+// APItoPBPropertySchema onverts an apitypes PropertySchema to the protobuffer
+// PropertySchema message that will eb stored in backend storage
+func APItoPBPropertySchema(as *apitypes.PropertySchema) *pb.PropertySchema {
 	res := &pb.PropertySchema{
 		Types:   []pb.PropertySchema_Type{},
 		Pattern: as.Pattern,

--- a/proto/defs/property.proto
+++ b/proto/defs/property.proto
@@ -121,12 +121,12 @@ message PropertyDefinition {
     string type = 2;
     // The property key to apply the property definition to. e.g. "architecture"
     string key = 3;
-    // Describes the format and type constraints of the value of the property
-    string schema = 4;
     // true if this property key must be set on objects of this type
-    bool is_required = 5;
+    bool is_required = 4;
+    // Describes the format and type constraints of the value of the property
+    PropertySchema schema = 50;
     // Collection of access permissions applied to this property
-    repeated PropertyPermission permissions = 50;
+    repeated PropertyPermission permissions = 51;
 }
 
 // Used in matching property definition records
@@ -134,7 +134,7 @@ message PropertyDefinitionFilter {
     PartitionFilter partition = 1;
     ObjectTypeFilter type = 2;
     // A search term on the property definition's property key
-    string search = 4;
+    string search = 3;
     // Indicates the search should be a prefix expression
-    bool use_prefix = 5;
+    bool use_prefix = 4;
 }


### PR DESCRIPTION
Store the property's schema as a PropertySchema protobuffer message and
not a serialized JSONSchema string. Changes the way that property
definitions are printed in the runm client as well:

```
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh property-definition get runm.image owner_email
Partition:    68cfff01c16a46cc8b83bfb0e6ecc97b
Type:         runm.image
Key:          owner_email
Required:     false
Permissions:
  1: project: proj0 permission: READ/WRITE
  2: permission: READ
Schema:
  Types:
    - string
  Format: idn-email
```

Issue #21