### PR TITLE
add UUID to property definition

### DIFF
--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -80,24 +80,28 @@ $ROOT
     runm.machine -> serialized ObjectType Protobuffer message
     runm.provider -> serialized ObjectType Protobuffer message
     runm.provider_group -> serialized ObjectType Protobuffer message
-  objects/
-    by-uuid/
-      54b8d8d7e24c43799bbf70c16e921e52 -> serialized Object protobuffer message
-      60b53edd16764f6abc081ddb0a73e69c -> serialized Object protobuffer message
-      3bf3e700f11b4a7cb99244c554b3a856 -> serialized Object protobuffer message
+  objects/by-uuid/
+    54b8d8d7e24c43799bbf70c16e921e52 -> serialized Object message
+    60b53edd16764f6abc081ddb0a73e69c -> serialized Object message
+    3bf3e700f11b4a7cb99244c554b3a856 -> serialized Object message
   partitions/
     by-name/
       us-east.example.com -> d3873f99a21f45f5bce156c1f8b84b03
       us-west.example.com -> d79706e01fbd4e48aae89209061cdb71
     by-uuid/
-      d3873f99a21f45f5bce156c1f8b84b03 -> serialized Partition protobuffer message
-      d79706e01fbd4e48aae89209061cdb71 -> serialized Partition protobuffer message
+      d3873f99a21f45f5bce156c1f8b84b03 -> serialized Partition message
+      d79706e01fbd4e48aae89209061cdb71 -> serialized Partition message
     d3873f99a21f45f5bce156c1f8b84b03/
-    d79706e01fbd4e48aae89209061cdb71/
+    d79706e01fbd4e48aae89209061cdb71/A
+  property-definitions/by-uuid/
+    9ef32862afd54a32b4a6c5f11c590061 -> serialized PropertyDefinition message
+    f287341160ee4feba4012eb7f8125b82 -> serialized PropertyDefinition message
+    f2aaa1bffbba4d5e860404176564347e -> serialized PropertyDefinition message
 ```
 
-Above, you can see that `$ROOT` has three key namespaces, one called
-`object-types/`, one called `objects/by-uuid/` and another called `partitions/`.
+Above, you can see that `$ROOT` has four key namespaces, one called
+`object-types/`, one called `objects/by-uuid/` one called `partitions` and
+another called `property-definitions/by-uuid/`.
 
 The `$ROOT/object-types/` key namespace has a set of [valued keys](#Valued keys)
 describing the object types known to the system.
@@ -109,10 +113,13 @@ The valued keys in the `$ROOT/objects/by-uuid/` key namespace have the UUID of
 the object as the key and a serialized Google Protobuffer message of the
 [Object](../../../proto/defs/object.proto) itself as the value.
 
-**NOTE**: Having the serialized Object protobuffer message as the value of the
+**NOTE**: Having the serialized Object message as the value of the
 `$ROOT/objects/by-uuid/` key namespace's valued keys allows the `runm-metadata`
 service to answer queries like "get me the tags on this object" with an
 efficient single key fetch operation.
+
+The `$ROOT/property-definitions/by-uuid/` key namespace has a set of valued
+keys describing the property definitions known to the system.
 
 The `$ROOT/partitions/` key namespace has two key namespaces below it that
 implement indexes into partitions, called `by-name` and `by-uuid`. In addition
@@ -214,21 +221,17 @@ layout:
 $PROPERTY_DEFINITIONS (e.g. $ROOT/partitions/d79706e01fbd4e48aae89209061cdb71/property-definitions/)
   by-type/
     runm.image/
-      architecture -> serialized PropertySchema protobuffer message
+      9ef32862afd54a32b4a6c5f11c590061 -> 9ef32862afd54a32b4a6c5f11c590061
+      f287341160ee4feba4012eb7f8125b82 -> f287341160ee4feba4012eb7f8125b82
     runm.machine/
-      appgroup -> serialized PropertySchema protobuffer message
+      f2aaa1bffbba4d5e860404176564347e
 ```
 
 Above shows an example key namespace for `$PROPERTY_DEFINITIONS` in a partition
-where an administrator has defined two property schemas, one for `runm.image`
-object types with a property key of "architecture" and another for
-`runm.machine` object types with a property key of "appgroup". Under the key
-namespace representing the property schemas for an object type (e.g.
-`$PROPERTY_DEFINITIONS/by-type/runm.image`) are additional key namespaces, one for
-each property key that has a schema defined for it. The valued keys in those
-key namespaces have values that are the serialized Protobuffer message
-representing the [property definition](../../../proto/defs/property.proto)
-itself.
+where an administrator has defined three property schemas, two for `runm.image`
+object types and another for `runm.machine` object types. The values of the
+keys are UUIDs that can be looked up in the primary
+`$ROOT/property-definitions/by-uuid/` index.
 
 ### The `$PROPERTIES` key namespace
 

--- a/cmd/runm/commands/property_definition.go
+++ b/cmd/runm/commands/property_definition.go
@@ -105,6 +105,7 @@ func printPropertyDefinition(obj *pb.PropertyDefinition) {
 	fmt.Printf("Partition:    %s\n", obj.Partition)
 	fmt.Printf("Type:         %s\n", obj.Type)
 	fmt.Printf("Key:          %s\n", obj.Key)
+	fmt.Printf("UUID:         %s\n", obj.Uuid)
 	fmt.Printf("Required:     %s\n", strconv.FormatBool(obj.IsRequired))
 	if len(obj.Permissions) > 0 {
 		fmt.Printf("Permissions:\n")

--- a/cmd/runm/commands/property_definition_get.go
+++ b/cmd/runm/commands/property_definition_get.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"fmt"
+	"os"
+
 	"golang.org/x/net/context"
 
 	pb "github.com/runmachine-io/runmachine/proto"
@@ -8,6 +11,17 @@ import (
 )
 
 const (
+	usagePropDefGetUuidOpt       = `search by the property definition's UUID`
+	usagePropDefGetObjectTypeOpt = `search by the property definition's object type
+
+NOTE: Using this option will require specifying the property definition's key
+using the --key CLI option.
+`
+	usagePropDefGetKeyOpt = `search by the property definition's key
+
+NOTE: Using this option will require specifying the property definition's
+object type using the --object-type CLI option.
+`
 	usagePropDefGetPartitionOpt = `optional partition filter.
 
 If not set, defaults to the partition used in the user's session.
@@ -15,18 +29,37 @@ If not set, defaults to the partition used in the user's session.
 )
 
 var (
+	// Search by UUID
+	cliPropDefGetUuid string
+	// Search by object type (and key)
+	cliPropDefGetObjectType string
+	cliPropDefGetKey        string
 	// partition override. if empty, we use the session's partition
 	cliPropDefGetPartition string
 )
 
 var propertyDefinitionGetCommand = &cobra.Command{
-	Use:   "get <object_type> <key>",
+	Use:   "get",
 	Short: "Show information for a single property definition",
-	Args:  cobra.ExactArgs(2),
 	Run:   propertyDefinitionGet,
 }
 
 func setupPropertyDefinitionGetFlags() {
+	propertyDefinitionGetCommand.Flags().StringVarP(
+		&cliPropDefGetUuid,
+		"uuid", "", "",
+		usagePropDefGetUuidOpt,
+	)
+	propertyDefinitionGetCommand.Flags().StringVarP(
+		&cliPropDefGetObjectType,
+		"object-type", "", "",
+		usagePropDefGetObjectTypeOpt,
+	)
+	propertyDefinitionGetCommand.Flags().StringVarP(
+		&cliPropDefGetKey,
+		"key", "", "",
+		usagePropDefGetKeyOpt,
+	)
 	propertyDefinitionGetCommand.Flags().StringVarP(
 		&cliPropDefGetPartition,
 		"partition", "", "",
@@ -46,13 +79,23 @@ func propertyDefinitionGet(cmd *cobra.Command, args []string) {
 
 	session := getSession()
 
-	filter := &pb.PropertyDefinitionFilter{
-		Type: &pb.ObjectTypeFilter{
-			Search:    args[0],
-			UsePrefix: false,
-		},
-		Search:    args[1],
-		UsePrefix: false,
+	filter := &pb.PropertyDefinitionFilter{}
+
+	if cliPropDefGetUuid != "" {
+		filter.Uuid = cliPropDefGetUuid
+	} else {
+		if cliPropDefGetObjectType == "" || cliPropDefGetKey == "" {
+			fmt.Fprintf(
+				os.Stderr,
+				"Error: either specify --uuid or specify *BOTH* "+
+					"--object-type <TYPE> and --key <KEY>\n",
+			)
+			os.Exit(1)
+		}
+		filter.Type = &pb.ObjectTypeFilter{
+			Search: cliPropDefGetObjectType,
+		}
+		filter.Key = cliPropDefGetKey
 	}
 	if cliPropDefGetPartition != "" {
 		filter.Partition = &pb.PartitionFilter{

--- a/cmd/runm/commands/property_definition_list.go
+++ b/cmd/runm/commands/property_definition_list.go
@@ -29,6 +29,7 @@ expressions to filter by. $field may be any of the following:
 - partition: UUID or name of the partition the property definition belongs to
 - type: code of the object type (:see runm object-type list)
 - key: the property key to list property definitions for
+- uuid: the UUID of the property definition itself
 
 The $value should be an identifier or name for the $field. You can use an
 asterisk (*) to indicate a prefix match. For example, to list all property
@@ -47,6 +48,10 @@ objects that are a partition called part0:
 
 --filter "type=runm.machine partition=part0" \
 --filter "type=runm.image partition=part0"
+
+Find a property definition with a UUID of "f287341160ee4feba4012eb7f8125b82":
+
+--filter "uuid=f287341160ee4feba4012eb7f8125b82"
 `
 )
 
@@ -107,8 +112,10 @@ func buildPropertyDefinitionFilters() []*pb.PropertyDefinitionFilter {
 					Search:    value,
 					UsePrefix: usePrefix,
 				}
+			case "uuid":
+				filter.Uuid = value
 			case "key":
-				filter.Search = value
+				filter.Key = value
 				filter.UsePrefix = usePrefix
 			default:
 				fmt.Fprintf(
@@ -153,6 +160,7 @@ func propertyDefinitionList(cmd *cobra.Command, args []string) {
 		"Partition",
 		"Type",
 		"Key",
+		"UUID",
 		"Required?",
 	}
 	rows := make([][]string, len(msgs))
@@ -161,6 +169,7 @@ func propertyDefinitionList(cmd *cobra.Command, args []string) {
 			obj.Partition,
 			obj.Type,
 			obj.Key,
+			obj.Uuid,
 			strconv.FormatBool(obj.IsRequired),
 		}
 	}

--- a/pkg/metadata/errors.go
+++ b/pkg/metadata/errors.go
@@ -98,6 +98,10 @@ var (
 		codes.FailedPrecondition,
 		"at least one property definition filter is required.",
 	)
+	ErrPropertyDefinitionFilterInvalid = status.Errorf(
+		codes.FailedPrecondition,
+		"invalid property definition filter.",
+	)
 	ErrPropertyDefinitionDeleteFailed = status.Errorf(
 		codes.FailedPrecondition,
 		"failed to delete property definition (check response errors collection).",

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -212,18 +212,21 @@ func (s *Server) validateObjectProperty(
 	key string,
 	value string,
 ) (*pb.Property, error) {
-	propDef, err := s.store.PropertyDefinitionGetByPK(
-		&types.PropertyDefinitionPK{
-			Partition:   partition.Uuid,
-			ObjectType:  objType.Code,
-			PropertyKey: key,
+	pds, err := s.store.PropertyDefinitionList(
+		[]*types.PropertyDefinitionFilter{
+			&types.PropertyDefinitionFilter{
+				Partition: partition,
+				Type:      objType,
+				Key:       key,
+			},
 		},
 	)
-	if err != nil && err != errors.ErrNotFound {
+	if err != nil {
 		return nil, err
 	}
-	if propDef != nil {
-		err := s.validateValueWithSchema(value, propDef.Schema)
+	if len(pds) > 0 {
+		pd := pds[0]
+		err := s.validateValueWithSchema(value, pd.Schema)
 		if err != nil {
 			return nil, errors.ErrFailedPropertyDefinitionValidation(key, err)
 		}

--- a/pkg/metadata/property_definition_filter.go
+++ b/pkg/metadata/property_definition_filter.go
@@ -133,21 +133,23 @@ func (s *Server) expandPropertyDefinitionFilter(
 	// we supplied no partition filters, then go ahead and just return a single
 	// types.PropertyDefinitionFilter with the search term and prefix indicator for
 	// the property key.
-	if filter.Search != "" {
+	if filter.Key != "" || filter.Uuid != "" {
 		if len(res) > 0 {
 			// Now that we've expanded our partitions and object types, add in the
 			// original PropertyDefinitionFilter's Search and UsePrefix for each
 			// types.PropertyDefinitionFilter we've created
 			for _, pf := range res {
-				pf.Search = filter.Search
+				pf.Key = filter.Key
 				pf.UsePrefix = filter.UsePrefix
+				pf.Uuid = filter.Uuid
 			}
 		} else {
 			res = append(
 				res,
 				&types.PropertyDefinitionFilter{
-					Search:    filter.Search,
+					Key:       filter.Key,
 					UsePrefix: filter.UsePrefix,
+					Uuid:      filter.Uuid,
 				},
 			)
 		}

--- a/pkg/metadata/types/property_definition.go
+++ b/pkg/metadata/types/property_definition.go
@@ -9,18 +9,6 @@ import (
 	pb "github.com/runmachine-io/runmachine/proto"
 )
 
-// A property definition is always uniquely identified by partition UUID,
-// object type code and property key
-type PropertyDefinitionPK struct {
-	Partition   string
-	ObjectType  string
-	PropertyKey string
-}
-
-func (pk *PropertyDefinitionPK) String() string {
-	return pk.Partition + ":" + pk.ObjectType + ":" + pk.PropertyKey
-}
-
 // A specialized filter class that has already looked up specific partition and
 // object types (expanded from user-supplied partition and type filter
 // strings). Users pass pb.PropertyDefinitionFilter messages which contain optional
@@ -32,12 +20,13 @@ func (pk *PropertyDefinitionPK) String() string {
 type PropertyDefinitionFilter struct {
 	Partition *pb.Partition
 	Type      *pb.ObjectType
-	Search    string
+	Uuid      string
+	Key       string
 	UsePrefix bool
 }
 
 func (f *PropertyDefinitionFilter) IsEmpty() bool {
-	return f.Partition == nil && f.Type == nil && f.Search == ""
+	return f.Partition == nil && f.Type == nil && f.Key == "" && f.Uuid == ""
 }
 
 func (f *PropertyDefinitionFilter) String() string {
@@ -48,8 +37,11 @@ func (f *PropertyDefinitionFilter) String() string {
 	if f.Type != nil {
 		attrMap["object_type"] = f.Type.Code
 	}
-	if f.Search != "" {
-		attrMap["search"] = f.Search
+	if f.Uuid != "" {
+		attrMap["uuid"] = f.Uuid
+	}
+	if f.Key != "" {
+		attrMap["key"] = f.Key
 		attrMap["use_prefix"] = strconv.FormatBool(f.UsePrefix)
 	}
 	attrs := ""

--- a/proto/defs/property.proto
+++ b/proto/defs/property.proto
@@ -121,8 +121,10 @@ message PropertyDefinition {
     string type = 2;
     // The property key to apply the property definition to. e.g. "architecture"
     string key = 3;
+    // The property definition's globally-unique identifier
+    string uuid = 4;
     // true if this property key must be set on objects of this type
-    bool is_required = 4;
+    bool is_required = 6;
     // Describes the format and type constraints of the value of the property
     PropertySchema schema = 50;
     // Collection of access permissions applied to this property
@@ -133,8 +135,9 @@ message PropertyDefinition {
 message PropertyDefinitionFilter {
     PartitionFilter partition = 1;
     ObjectTypeFilter type = 2;
+    string uuid = 3;
     // A search term on the property definition's property key
-    string search = 3;
+    string key = 4;
     // Indicates the search should be a prefix expression
-    bool use_prefix = 4;
+    bool use_prefix = 5;
 }


### PR DESCRIPTION
In preparation for supporting project-specific property definitions, we
needed to add a globally-unique identifier to property definitions. This
patch adds a UUID member to the PropertyDefinition structs/messages and
re-organizations the etcd data layout for property definitions to
support a primary key lookup by UUID.

The `runm property-definition get` CLI command is also substantially
reworked. It now accepts either a --uuid <UUID> CLI option *or* a
--object-type and --key CLI option for searching for a specific property
definition:

```
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh property-definition get --object-type runm.image --key owner_email
Partition:    dbbb0b80c8714d7f8943dc9b5c2dcb19
Type:         runm.image
Key:          owner_email
UUID:         22ad160382d44818907a41876d319f8f
Required:     false
Permissions:
  - PROJECT(proj0) READ/WRITE
  - GLOBAL READ
Schema:
  Types:
    - string
  Format: idn-email
[jaypipes@uberbox runmachine]$ ./scripts/exec-runm-command.sh property-definition get --uuid 22ad160382d44818907a41876d319f8f
Partition:    dbbb0b80c8714d7f8943dc9b5c2dcb19
Type:         runm.image
Key:          owner_email
UUID:         22ad160382d44818907a41876d319f8f
Required:     false
Permissions:
  - PROJECT(proj0) READ/WRITE
  - GLOBAL READ
Schema:
  Types:
    - string
  Format: idn-email
```

Issue #81