### PR TITLE
update way in which filters are constructed in metadata service

### DIFF
--- a/cmd/runm-metadata/docs/data_layout.md
+++ b/cmd/runm-metadata/docs/data_layout.md
@@ -165,14 +165,12 @@ and the object metadata (properties and tags) in the partition:
 ```
 $PARTITION (e.g. $ROOT/partitions/d79706e01fbd4e48aae89209061cdb71/)
   objects/
-  property-definitions/
   properties/
   tags/
 ```
 
 We will refer to the `$PARTITION/objects/` key namespace as `$OBJECT` from here
-on. Similarly, we will refer to `$PARTITION/property-definitions/` as just
-`$PROPERTY_DEFINITIONS`, `$PARTITION/properties/` as just `$PROPERTIES` and
+on. Similarly, we will refer to `$PARTITION/properties/` as just `$PROPERTIES` and
 `$PARTITION/tags,` as just `$TAGS`. Each of these key namespaces is described
 in detail in the following sections.
 
@@ -210,28 +208,6 @@ means that these objects are not specific to a project, and therefore the
 `$OBJECTS/by-type/runm.provider_group/by-name` is the only index key namespace
 for these types of objects (there is no `by-project/` sub key namespace under
 the object type).
-
-### The `$PROPERTY_DEFINITIONS` key namespace
-
-The `$PROPERTY_DEFINITIONS` key namespace stores information about the property
-schemas defined within a partition. The key namespace itself has a very simple
-layout:
-
-```
-$PROPERTY_DEFINITIONS (e.g. $ROOT/partitions/d79706e01fbd4e48aae89209061cdb71/property-definitions/)
-  by-type/
-    runm.image/
-      9ef32862afd54a32b4a6c5f11c590061 -> 9ef32862afd54a32b4a6c5f11c590061
-      f287341160ee4feba4012eb7f8125b82 -> f287341160ee4feba4012eb7f8125b82
-    runm.machine/
-      f2aaa1bffbba4d5e860404176564347e
-```
-
-Above shows an example key namespace for `$PROPERTY_DEFINITIONS` in a partition
-where an administrator has defined three property schemas, two for `runm.image`
-object types and another for `runm.machine` object types. The values of the
-keys are UUIDs that can be looked up in the primary
-`$ROOT/property-definitions/by-uuid/` index.
 
 ### The `$PROPERTIES` key namespace
 

--- a/cmd/runm/commands/common.go
+++ b/cmd/runm/commands/common.go
@@ -59,6 +59,8 @@ var (
 	listSort   string
 	// filepath to read a document to send to the server for create/update operations
 	cliObjectDocPath string
+	// CLI-provided set of --filter options
+	cliFilters = []string{}
 )
 
 func exitIfConnectErr(err error) {

--- a/cmd/runm/commands/object.go
+++ b/cmd/runm/commands/object.go
@@ -2,10 +2,60 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	pb "github.com/runmachine-io/runmachine/proto"
 	"github.com/spf13/cobra"
+)
+
+const (
+	usageObjectFilterOption = `optional filter to apply.
+
+--filter <filter expression>
+
+Multiple filters may be applied to the object list operation. Each filter's
+field expression is evaluated using an "AND" condition. Multiple filters are
+evaluated using an "OR" condition.
+
+The <filter expression> value is a whitespace-separated set of $field=$value
+expressions to filter by. $field may be any of the following:
+
+- partition: UUID or name of the partition the object belongs to
+- type: code of the object type (:see runm object-type list)
+- project: identifier of the project the object belongs to
+- uuid: the UUID of the object itself
+- name: name of the object
+
+The $value should be an identifier or name for the $field. You can use an
+asterisk (*) to indicate a prefix match. For example, to list all objects of
+type "runm.machine" with names that start with the string "east", you would use
+--filter "type=runm.machine object=east*"
+
+Examples:
+
+Find all runm.image objects starting with "db" in the "admin" project:
+
+--filter "type=runm.image object=db* project=admin"
+
+Find all runm.machine objects OR runm.image objects that are a partition called
+part0:
+
+--filter "type=runm.machine partition=part0" \
+--filter "type=runm.image partition=part0"
+
+Find any object in the "admin" project that has a name starting with "db":
+
+--filter "project=admin name=db*"
+
+Find an object with a UUID of "f287341160ee4feba4012eb7f8125b82":
+
+--filter "uuid=f287341160ee4feba4012eb7f8125b82"
+`
+	errMsgFieldExprFormat = `ERROR: field expression %s expected to be in the form $field=$value
+`
+	errMsgUnknownFieldInFieldExpr = `ERROR: field expression %s contained unknown field %s
+`
 )
 
 var objectCommand = &cobra.Command{
@@ -18,6 +68,61 @@ func init() {
 	objectCommand.AddCommand(objectGetCommand)
 	objectCommand.AddCommand(objectCreateCommand)
 	objectCommand.AddCommand(objectDeleteCommand)
+}
+
+func buildObjectFilters() []*pb.ObjectFilter {
+	filters := make([]*pb.ObjectFilter, 0)
+	// Each --filter <field expression> supplied by the user will have one or
+	// more $field=$value segments to it, separated by spaces. Split those
+	// $field=$value pairs up and evaluate each $field and $value string for
+	// fitness
+	for _, f := range cliFilters {
+		fieldExprs := strings.Fields(f)
+		filter := &pb.ObjectFilter{}
+		for _, fieldExpr := range fieldExprs {
+			kvs := strings.SplitN(fieldExpr, "=", 2)
+			if len(kvs) != 2 {
+				fmt.Fprintf(os.Stderr, errMsgFieldExprFormat, fieldExpr)
+				os.Exit(1)
+			}
+			field := kvs[0]
+			value := kvs[1]
+			usePrefix := false
+			if strings.HasSuffix(value, "*") {
+				usePrefix = true
+				value = strings.TrimRight(value, "*")
+			}
+			switch field {
+			case "partition":
+				filter.Partition = &pb.PartitionFilter{
+					Search:    value,
+					UsePrefix: usePrefix,
+				}
+			case "type":
+				filter.Type = &pb.ObjectTypeFilter{
+					Search:    value,
+					UsePrefix: usePrefix,
+				}
+			case "project":
+				filter.Project = value
+			case "uuid":
+				filter.Uuid = value
+			case "name":
+				filter.Name = value
+				filter.UsePrefix = usePrefix
+			default:
+				fmt.Fprintf(
+					os.Stderr,
+					errMsgUnknownFieldInFieldExpr,
+					fieldExpr,
+					field,
+				)
+				os.Exit(1)
+			}
+		}
+		filters = append(filters, filter)
+	}
+	return filters
 }
 
 func printObject(obj *pb.Object) {

--- a/cmd/runm/commands/object_delete.go
+++ b/cmd/runm/commands/object_delete.go
@@ -20,10 +20,10 @@ var objectDeleteCommand = &cobra.Command{
 
 func setupObjectDeleteFlags() {
 	objectDeleteCommand.Flags().StringArrayVarP(
-		&cliObjectFilters, // defined in cmd/runm/commands/object_list.go
+		&cliFilters,
 		"filter", "f",
 		nil,
-		usageObjectFilterOption, // defined in cmd/runm/commands/object_list.go
+		usageObjectFilterOption,
 	)
 }
 

--- a/cmd/runm/commands/object_list.go
+++ b/cmd/runm/commands/object_list.go
@@ -1,65 +1,14 @@
 package commands
 
 import (
-	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"golang.org/x/net/context"
 
 	"github.com/olekukonko/tablewriter"
 	pb "github.com/runmachine-io/runmachine/proto"
 	"github.com/spf13/cobra"
-)
-
-const (
-	usageObjectFilterOption = `optional filter to apply.
-
---filter <filter expression>
-
-Multiple filters may be applied to the object list operation. Each filter's
-field expression is evaluated using an "AND" condition. Multiple filters are
-evaluated using an "OR" condition.
-
-The <filter expression> value is a whitespace-separated set of $field=$value
-expressions to filter by. $field may be any of the following:
-
-- partition: UUID or name of the partition the object belongs to
-- type: code of the object type (:see runm object-type list)
-- project: identifier of the project the object belongs to
-- object: UUID or name of the object
-
-The $value should be an identifier or name for the $field. You can use an
-asterisk (*) to indicate a prefix match. For example, to list all objects of
-type "runm.machine" with names that start with the string "east", you would use
---filter "type=runm.machine object=east*"
-
-Examples:
-
-Find all runm.image objects starting with "db" in the "admin" project:
-
---filter "type=runm.image object=db* project=admin"
-
-Find all runm.machine objects OR runm.image objects that are a partition called
-part0:
-
---filter "type=runm.machine partition=part0" \
---filter "type=runm.image partition=part0"
-
-Find any object in the "admin" project that has a name starting with "db":
-
---filter "project=admin object=db*"
-`
-	errMsgFieldExprFormat = `ERROR: field expression %s expected to be in the form $field=$value
-`
-	errMsgUnknownFieldInFieldExpr = `ERROR: field expression %s contained unknown field %s
-`
-)
-
-var (
-	// CLI-provided set of --filter options
-	cliObjectFilters = []string{}
 )
 
 var objectListCommand = &cobra.Command{
@@ -70,7 +19,7 @@ var objectListCommand = &cobra.Command{
 
 func setupObjectListFlags() {
 	objectListCommand.Flags().StringArrayVarP(
-		&cliObjectFilters,
+		&cliFilters,
 		"filter", "f",
 		nil,
 		usageObjectFilterOption,
@@ -79,59 +28,6 @@ func setupObjectListFlags() {
 
 func init() {
 	setupObjectListFlags()
-}
-
-func buildObjectFilters() []*pb.ObjectFilter {
-	filters := make([]*pb.ObjectFilter, 0)
-	// Each --filter <field expression> supplied by the user will have one or
-	// more $field=$value segments to it, separated by spaces. Split those
-	// $field=$value pairs up and evaluate each $field and $value string for
-	// fitness
-	for _, f := range cliObjectFilters {
-		fieldExprs := strings.Fields(f)
-		filter := &pb.ObjectFilter{}
-		for _, fieldExpr := range fieldExprs {
-			kvs := strings.SplitN(fieldExpr, "=", 2)
-			if len(kvs) != 2 {
-				fmt.Fprintf(os.Stderr, errMsgFieldExprFormat, fieldExpr)
-				os.Exit(1)
-			}
-			field := kvs[0]
-			value := kvs[1]
-			usePrefix := false
-			if strings.HasSuffix(value, "*") {
-				usePrefix = true
-				value = strings.TrimRight(value, "*")
-			}
-			switch field {
-			case "partition":
-				filter.Partition = &pb.PartitionFilter{
-					Search:    value,
-					UsePrefix: usePrefix,
-				}
-			case "type":
-				filter.Type = &pb.ObjectTypeFilter{
-					Search:    value,
-					UsePrefix: usePrefix,
-				}
-			case "project":
-				filter.Project = value
-			case "object":
-				filter.Search = value
-				filter.UsePrefix = usePrefix
-			default:
-				fmt.Fprintf(
-					os.Stderr,
-					errMsgUnknownFieldInFieldExpr,
-					fieldExpr,
-					field,
-				)
-				os.Exit(1)
-			}
-		}
-		filters = append(filters, filter)
-	}
-	return filters
 }
 
 func objectList(cmd *cobra.Command, args []string) {

--- a/cmd/runm/commands/property_definition.go
+++ b/cmd/runm/commands/property_definition.go
@@ -2,11 +2,54 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 
 	apitypes "github.com/runmachine-io/runmachine/pkg/api/types"
 	pb "github.com/runmachine-io/runmachine/proto"
 	"github.com/spf13/cobra"
+)
+
+const (
+	usagePropertyDefinitionFilterOption = `optional filter to apply.
+
+--filter <filter expression>
+
+Multiple filters may be applied to the property-schema list operation. Each
+filter's field expression is evaluated using an "AND" condition. Multiple
+filters are evaluated using an "OR" condition.
+
+The <filter expression> value is a whitespace-separated set of $field=$value
+expressions to filter by. $field may be any of the following:
+
+- partition: UUID or name of the partition the property definition belongs to
+- type: code of the object type (:see runm object-type list)
+- key: the property key to list property definitions for
+- uuid: the UUID of the property definition itself
+
+The $value should be an identifier or name for the $field. You can use an
+asterisk (*) to indicate a prefix match. For example, to list all property
+schemas for objects of type "runm.machine" for property keys that start with
+the string "arch", you would use --filter "type=runm.machine key=arch*"
+
+Examples:
+
+Find all property definitions that apply to runm.image objects in a partition
+beginning with "east":
+
+--filter "type=runm.image partition=east*"
+
+Find all property definitions that apply to runm.machine objects OR runm.image
+objects that are a partition called part0:
+
+--filter "type=runm.machine partition=part0" \
+--filter "type=runm.image partition=part0"
+
+Find a property definition with a UUID of "f287341160ee4feba4012eb7f8125b82":
+
+--filter "uuid=f287341160ee4feba4012eb7f8125b82"
+`
 )
 
 var (
@@ -44,6 +87,59 @@ func init() {
 	propertyDefinitionCommand.AddCommand(propertyDefinitionGetCommand)
 	propertyDefinitionCommand.AddCommand(propertyDefinitionSetCommand)
 	propertyDefinitionCommand.AddCommand(propertyDefinitionDeleteCommand)
+}
+
+func buildPropertyDefinitionFilters() []*pb.PropertyDefinitionFilter {
+	filters := make([]*pb.PropertyDefinitionFilter, 0)
+	// Each --filter <field expression> supplied by the user will have one or
+	// more $field=$value segments to it, separated by spaces. Split those
+	// $field=$value pairs up and evaluate each $field and $value string for
+	// fitness
+	for _, f := range cliFilters {
+		fieldExprs := strings.Fields(f)
+		filter := &pb.PropertyDefinitionFilter{}
+		for _, fieldExpr := range fieldExprs {
+			kvs := strings.SplitN(fieldExpr, "=", 2)
+			if len(kvs) != 2 {
+				fmt.Fprintf(os.Stderr, errMsgFieldExprFormat, fieldExpr)
+				os.Exit(1)
+			}
+			field := kvs[0]
+			value := kvs[1]
+			usePrefix := false
+			if strings.HasSuffix(value, "*") {
+				usePrefix = true
+				value = strings.TrimRight(value, "*")
+			}
+			switch field {
+			case "partition":
+				filter.Partition = &pb.PartitionFilter{
+					Search:    value,
+					UsePrefix: usePrefix,
+				}
+			case "type":
+				filter.Type = &pb.ObjectTypeFilter{
+					Search:    value,
+					UsePrefix: usePrefix,
+				}
+			case "uuid":
+				filter.Uuid = value
+			case "key":
+				filter.Key = value
+				filter.UsePrefix = usePrefix
+			default:
+				fmt.Fprintf(
+					os.Stderr,
+					errMsgUnknownFieldInFieldExpr,
+					fieldExpr,
+					field,
+				)
+				os.Exit(1)
+			}
+		}
+		filters = append(filters, filter)
+	}
+	return filters
 }
 
 func printPropertySchema(obj *pb.PropertySchema) {

--- a/cmd/runm/commands/property_definition_delete.go
+++ b/cmd/runm/commands/property_definition_delete.go
@@ -20,10 +20,10 @@ var propertyDefinitionDeleteCommand = &cobra.Command{
 
 func setupPropertyDefinitionDeleteFlags() {
 	propertyDefinitionDeleteCommand.Flags().StringArrayVarP(
-		&cliPropertyDefinitionFilters, // defined in cmd/runm/commands/property_definition_list.go
+		&cliFilters,
 		"filter", "f",
 		nil,
-		usagePropertyDefinitionFilterOption, // defined in cmd/runm/commands/property_definition_list.go
+		usagePropertyDefinitionFilterOption,
 	)
 }
 

--- a/cmd/runm/commands/property_definition_get.go
+++ b/cmd/runm/commands/property_definition_get.go
@@ -41,7 +41,7 @@ var propertyDefinitionGetCommand = &cobra.Command{
 
 func setupPropertyDefinitionGetFlags() {
 	propertyDefinitionGetCommand.Flags().StringArrayVarP(
-		&cliPropertyDefinitionFilters,
+		&cliFilters,
 		"filter", "f",
 		nil,
 		usagePropertyDefinitionFilterOption,

--- a/cmd/runm/commands/property_definition_list.go
+++ b/cmd/runm/commands/property_definition_list.go
@@ -1,63 +1,15 @@
 package commands
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"strconv"
-	"strings"
 
 	"golang.org/x/net/context"
 
 	"github.com/olekukonko/tablewriter"
 	pb "github.com/runmachine-io/runmachine/proto"
 	"github.com/spf13/cobra"
-)
-
-const (
-	usagePropertyDefinitionFilterOption = `optional filter to apply.
-
---filter <filter expression>
-
-Multiple filters may be applied to the property-schema list operation. Each
-filter's field expression is evaluated using an "AND" condition. Multiple
-filters are evaluated using an "OR" condition.
-
-The <filter expression> value is a whitespace-separated set of $field=$value
-expressions to filter by. $field may be any of the following:
-
-- partition: UUID or name of the partition the property definition belongs to
-- type: code of the object type (:see runm object-type list)
-- key: the property key to list property definitions for
-- uuid: the UUID of the property definition itself
-
-The $value should be an identifier or name for the $field. You can use an
-asterisk (*) to indicate a prefix match. For example, to list all property
-schemas for objects of type "runm.machine" for property keys that start with
-the string "arch", you would use --filter "type=runm.machine key=arch*"
-
-Examples:
-
-Find all property definitions that apply to runm.image objects in a partition
-beginning with "east":
-
---filter "type=runm.image partition=east*"
-
-Find all property definitions that apply to runm.machine objects OR runm.image
-objects that are a partition called part0:
-
---filter "type=runm.machine partition=part0" \
---filter "type=runm.image partition=part0"
-
-Find a property definition with a UUID of "f287341160ee4feba4012eb7f8125b82":
-
---filter "uuid=f287341160ee4feba4012eb7f8125b82"
-`
-)
-
-var (
-	// CLI-provided set of --filter options
-	cliPropertyDefinitionFilters = []string{}
 )
 
 var propertyDefinitionListCommand = &cobra.Command{
@@ -68,7 +20,7 @@ var propertyDefinitionListCommand = &cobra.Command{
 
 func setupPropertyDefinitionListFlags() {
 	propertyDefinitionListCommand.Flags().StringArrayVarP(
-		&cliPropertyDefinitionFilters,
+		&cliFilters,
 		"filter", "f",
 		nil,
 		usagePropertyDefinitionFilterOption,
@@ -77,59 +29,6 @@ func setupPropertyDefinitionListFlags() {
 
 func init() {
 	setupPropertyDefinitionListFlags()
-}
-
-func buildPropertyDefinitionFilters() []*pb.PropertyDefinitionFilter {
-	filters := make([]*pb.PropertyDefinitionFilter, 0)
-	// Each --filter <field expression> supplied by the user will have one or
-	// more $field=$value segments to it, separated by spaces. Split those
-	// $field=$value pairs up and evaluate each $field and $value string for
-	// fitness
-	for _, f := range cliPropertyDefinitionFilters {
-		fieldExprs := strings.Fields(f)
-		filter := &pb.PropertyDefinitionFilter{}
-		for _, fieldExpr := range fieldExprs {
-			kvs := strings.SplitN(fieldExpr, "=", 2)
-			if len(kvs) != 2 {
-				fmt.Fprintf(os.Stderr, errMsgFieldExprFormat, fieldExpr)
-				os.Exit(1)
-			}
-			field := kvs[0]
-			value := kvs[1]
-			usePrefix := false
-			if strings.HasSuffix(value, "*") {
-				usePrefix = true
-				value = strings.TrimRight(value, "*")
-			}
-			switch field {
-			case "partition":
-				filter.Partition = &pb.PartitionFilter{
-					Search:    value,
-					UsePrefix: usePrefix,
-				}
-			case "type":
-				filter.Type = &pb.ObjectTypeFilter{
-					Search:    value,
-					UsePrefix: usePrefix,
-				}
-			case "uuid":
-				filter.Uuid = value
-			case "key":
-				filter.Key = value
-				filter.UsePrefix = usePrefix
-			default:
-				fmt.Fprintf(
-					os.Stderr,
-					errMsgUnknownFieldInFieldExpr,
-					fieldExpr,
-					field,
-				)
-				os.Exit(1)
-			}
-		}
-		filters = append(filters, filter)
-	}
-	return filters
 }
 
 func propertyDefinitionList(cmd *cobra.Command, args []string) {

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -223,7 +223,10 @@ func (s *Server) validateObjectProperty(
 					Op:         types.OP_EQUAL,
 					ObjectType: objType,
 				},
-				Key: key,
+				PropertyKey: &types.PropertyKeyCondition{
+					Op:          types.OP_EQUAL,
+					PropertyKey: key,
+				},
 			},
 		},
 	)

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -215,9 +215,15 @@ func (s *Server) validateObjectProperty(
 	pds, err := s.store.PropertyDefinitionList(
 		[]*types.PropertyDefinitionFilter{
 			&types.PropertyDefinitionFilter{
-				Partition: partition,
-				Type:      objType,
-				Key:       key,
+				Partition: &types.PartitionCondition{
+					Op:        types.OP_EQUAL,
+					Partition: partition,
+				},
+				ObjectType: &types.ObjectTypeCondition{
+					Op:         types.OP_EQUAL,
+					ObjectType: objType,
+				},
+				Key: key,
 			},
 		},
 	)

--- a/pkg/metadata/object.go
+++ b/pkg/metadata/object.go
@@ -81,7 +81,7 @@ func (s *Server) ObjectGet(
 		// an unknown error after logging it.
 		s.log.ERR(
 			"failed to retrieve object with search filter %s: %s",
-			req.Filter.Search,
+			req.Filter,
 			err,
 		)
 		return nil, ErrUnknown

--- a/pkg/metadata/object_filter.go
+++ b/pkg/metadata/object_filter.go
@@ -152,7 +152,7 @@ func (s *Server) expandObjectFilter(
 	// partition filters, then go ahead and just return a single
 	// types.ObjectFilter with the search term and prefix indicator for the
 	// object.
-	if filter.Search != "" || filter.Project != "" {
+	if filter.Name != "" || filter.Uuid != "" || filter.Project != "" {
 		if len(res) == 0 {
 			res = append(res, &types.ObjectFilter{})
 		}
@@ -160,21 +160,20 @@ func (s *Server) expandObjectFilter(
 		// original ObjectFilter's Search and UsePrefix for each
 		// types.ObjectFilter we've created
 		for _, pf := range res {
-			if filter.Search != "" {
-				if util.IsUuidLike(filter.Search) {
-					pf.Uuid = &types.UuidCondition{
-						Op:   types.OP_EQUAL,
-						Uuid: util.NormalizeUuid(filter.Search),
-					}
-				} else {
-					op := types.OP_EQUAL
-					if filter.UsePrefix {
-						op = types.OP_GREATER_THAN_EQUAL
-					}
-					pf.Name = &types.NameCondition{
-						Op:   op,
-						Name: filter.Search,
-					}
+			if filter.Uuid != "" {
+				pf.Uuid = &types.UuidCondition{
+					Op:   types.OP_EQUAL,
+					Uuid: util.NormalizeUuid(filter.Uuid),
+				}
+			}
+			if filter.Name != "" {
+				op := types.OP_EQUAL
+				if filter.UsePrefix {
+					op = types.OP_GREATER_THAN_EQUAL
+				}
+				pf.Name = &types.NameCondition{
+					Op:   op,
+					Name: filter.Name,
 				}
 			}
 			pf.Project = filter.Project

--- a/pkg/metadata/object_filter.go
+++ b/pkg/metadata/object_filter.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"github.com/runmachine-io/runmachine/pkg/errors"
 	"github.com/runmachine-io/runmachine/pkg/metadata/types"
+	"github.com/runmachine-io/runmachine/pkg/util"
 	pb "github.com/runmachine-io/runmachine/proto"
 )
 
@@ -159,9 +160,18 @@ func (s *Server) expandObjectFilter(
 		// original ObjectFilter's Search and UsePrefix for each
 		// types.ObjectFilter we've created
 		for _, pf := range res {
+			if filter.Search != "" {
+				if util.IsUuidLike(filter.Search) {
+					pf.Uuid = &types.UuidCondition{
+						Op:   types.OP_EQUAL,
+						Uuid: util.NormalizeUuid(filter.Search),
+					}
+				} else {
+					pf.Search = filter.Search
+					pf.UsePrefix = filter.UsePrefix
+				}
+			}
 			pf.Project = filter.Project
-			pf.Search = filter.Search
-			pf.UsePrefix = filter.UsePrefix
 		}
 	}
 	return res, nil

--- a/pkg/metadata/object_filter.go
+++ b/pkg/metadata/object_filter.go
@@ -11,8 +11,8 @@ import (
 // partition that the user's session is on.
 func (s *Server) defaultObjectFilter(
 	session *pb.Session,
-) (*types.ObjectListFilter, error) {
-	part, err := s.store.PartitionGet(session.Partition)
+) (*types.ObjectFilter, error) {
+	p, err := s.store.PartitionGet(session.Partition)
 	if err != nil {
 		if err == errors.ErrNotFound {
 			// Just return nil since clearly we can have no
@@ -26,28 +26,31 @@ func (s *Server) defaultObjectFilter(
 		}
 		return nil, err
 	}
-	return &types.ObjectListFilter{
-		Partition: part,
-		Project:   session.Project,
+	return &types.ObjectFilter{
+		Partition: &types.PartitionCondition{
+			Op:        types.OP_EQUAL,
+			Partition: p,
+		},
+		Project: session.Project,
 	}, nil
 }
 
 // expandObjectFilter is used to expand an ObjectFilter, which may contain
 // PartitionFilter and ObjectTypeFilter objects that themselves may resolve to
-// multiple partitions or object types, to a set of types.ObjectListFilter
-// objects. A types.ObjectListFilter is used to describe a filter on objects in
+// multiple partitions or object types, to a set of types.ObjectFilter
+// objects. A types.ObjectFilter is used to describe a filter on objects in
 // a *specific* partition and having a *specific* object type.
 func (s *Server) expandObjectFilter(
 	session *pb.Session,
 	filter *pb.ObjectFilter,
-) ([]*types.ObjectListFilter, error) {
-	res := make([]*types.ObjectListFilter, 0)
+) ([]*types.ObjectFilter, error) {
+	res := make([]*types.ObjectFilter, 0)
 	var err error
-	// A set of partition UUIDs that we'll create types.ObjectListFilters with.
+	// A set of partition UUIDs that we'll create types.ObjectFilters with.
 	// These are the UUIDs of any partitions that match the PartitionFilter in
 	// the supplied pb.ObjectFilter
 	var partitions []*pb.Partition
-	// A set of object type codes that we'll create types.ObjectListFilters
+	// A set of object type codes that we'll create types.ObjectFilters
 	// with. These are the codes of object types that match the
 	// ObjectTypeFilter in the supplied ObjectFilter
 	var objTypes []*pb.ObjectType
@@ -102,20 +105,29 @@ func (s *Server) expandObjectFilter(
 	}
 
 	// OK, if we've expanded partition or object type, we need to construct
-	// types.ObjectListFilter objects containing the combination of all the
+	// types.ObjectFilter objects containing the combination of all the
 	// expanded partitions and object types.
 	if len(partitions) > 0 {
 		for _, p := range partitions {
 			if len(objTypes) == 0 {
-				f := &types.ObjectListFilter{
-					Partition: p,
+				f := &types.ObjectFilter{
+					Partition: &types.PartitionCondition{
+						Op:        types.OP_EQUAL,
+						Partition: p,
+					},
 				}
 				res = append(res, f)
 			} else {
 				for _, ot := range objTypes {
-					f := &types.ObjectListFilter{
-						Partition: p,
-						Type:      ot,
+					f := &types.ObjectFilter{
+						Partition: &types.PartitionCondition{
+							Op:        types.OP_EQUAL,
+							Partition: p,
+						},
+						ObjectType: &types.ObjectTypeCondition{
+							Op:         types.OP_EQUAL,
+							ObjectType: ot,
+						},
 					}
 					res = append(res, f)
 				}
@@ -123,38 +135,33 @@ func (s *Server) expandObjectFilter(
 		}
 	} else if len(objTypes) > 0 {
 		for _, ot := range objTypes {
-			f := &types.ObjectListFilter{
-				Type: ot,
+			f := &types.ObjectFilter{
+				ObjectType: &types.ObjectTypeCondition{
+					Op:         types.OP_EQUAL,
+					ObjectType: ot,
+				},
 			}
 			res = append(res, f)
 		}
 	}
 
 	// If we've expanded the supplied partition filters into multiple
-	// types.ObjectListFilters, then we need to add our supplied ObjectFilter's
+	// types.ObjectFilters, then we need to add our supplied ObjectFilter's
 	// search and use prefix for the object's UUID/name. If we supplied no
 	// partition filters, then go ahead and just return a single
-	// types.ObjectListFilter with the search term and prefix indicator for the
+	// types.ObjectFilter with the search term and prefix indicator for the
 	// object.
 	if filter.Search != "" || filter.Project != "" {
-		if len(res) > 0 {
-			// Now that we've expanded our partitions and object types, add in the
-			// original ObjectFilter's Search and UsePrefix for each
-			// types.ObjectListFilter we've created
-			for _, pf := range res {
-				pf.Project = filter.Project
-				pf.Search = filter.Search
-				pf.UsePrefix = filter.UsePrefix
-			}
-		} else {
-			res = append(
-				res,
-				&types.ObjectListFilter{
-					Project:   filter.Project,
-					Search:    filter.Search,
-					UsePrefix: filter.UsePrefix,
-				},
-			)
+		if len(res) == 0 {
+			res = append(res, &types.ObjectFilter{})
+		}
+		// Now that we've expanded our partitions and object types, add in the
+		// original ObjectFilter's Search and UsePrefix for each
+		// types.ObjectFilter we've created
+		for _, pf := range res {
+			pf.Project = filter.Project
+			pf.Search = filter.Search
+			pf.UsePrefix = filter.UsePrefix
 		}
 	}
 	return res, nil
@@ -164,13 +171,13 @@ func (s *Server) expandObjectFilter(
 // ObjectFilter messages. It then expands those supplied ObjectFilter messages
 // if they contain partition or object type filters that have a prefix. If no
 // ObjectFilter messages are passed to this method, it returns the default
-// types.ObjectListFilter which will return all objects for the Session's partition
+// types.ObjectFilter which will return all objects for the Session's partition
 // and project.
 func (s *Server) normalizeObjectFilters(
 	session *pb.Session,
 	any []*pb.ObjectFilter,
-) ([]*types.ObjectListFilter, error) {
-	res := make([]*types.ObjectListFilter, 0)
+) ([]*types.ObjectFilter, error) {
+	res := make([]*types.ObjectFilter, 0)
 	for _, filter := range any {
 		if pfs, err := s.expandObjectFilter(session, filter); err != nil {
 			if err == errors.ErrNotFound {

--- a/pkg/metadata/object_filter.go
+++ b/pkg/metadata/object_filter.go
@@ -167,8 +167,14 @@ func (s *Server) expandObjectFilter(
 						Uuid: util.NormalizeUuid(filter.Search),
 					}
 				} else {
-					pf.Search = filter.Search
-					pf.UsePrefix = filter.UsePrefix
+					op := types.OP_EQUAL
+					if filter.UsePrefix {
+						op = types.OP_GREATER_THAN_EQUAL
+					}
+					pf.Name = &types.NameCondition{
+						Op:   op,
+						Name: filter.Search,
+					}
 				}
 			}
 			pf.Project = filter.Project

--- a/pkg/metadata/property_definition_filter.go
+++ b/pkg/metadata/property_definition_filter.go
@@ -156,17 +156,25 @@ func (s *Server) expandPropertyDefinitionFilter(
 			for _, pf := range res {
 				pf.Key = filter.Key
 				pf.UsePrefix = filter.UsePrefix
-				pf.Uuid = filter.Uuid
+				if filter.Uuid != "" {
+					pf.Uuid = &types.UuidCondition{
+						Op:   types.OP_EQUAL,
+						Uuid: filter.Uuid,
+					}
+				}
 			}
 		} else {
-			res = append(
-				res,
-				&types.PropertyDefinitionFilter{
-					Key:       filter.Key,
-					UsePrefix: filter.UsePrefix,
-					Uuid:      filter.Uuid,
-				},
-			)
+			pf := &types.PropertyDefinitionFilter{
+				Key:       filter.Key,
+				UsePrefix: filter.UsePrefix,
+			}
+			if filter.Uuid != "" {
+				pf.Uuid = &types.UuidCondition{
+					Op:   types.OP_EQUAL,
+					Uuid: filter.Uuid,
+				}
+			}
+			res = append(res, pf)
 		}
 	}
 	return res, nil

--- a/pkg/metadata/property_definition_filter.go
+++ b/pkg/metadata/property_definition_filter.go
@@ -149,24 +149,22 @@ func (s *Server) expandPropertyDefinitionFilter(
 	// types.PropertyDefinitionFilter with the search term and prefix indicator for
 	// the property key.
 	if filter.Key != "" || filter.Uuid != "" {
-		if len(res) > 0 {
-			// Now that we've expanded our partitions and object types, add in the
-			// original PropertyDefinitionFilter's Search and UsePrefix for each
-			// types.PropertyDefinitionFilter we've created
-			for _, pf := range res {
-				pf.Key = filter.Key
-				pf.UsePrefix = filter.UsePrefix
-				if filter.Uuid != "" {
-					pf.Uuid = &types.UuidCondition{
-						Op:   types.OP_EQUAL,
-						Uuid: filter.Uuid,
-					}
+		if len(res) == 0 {
+			res = append(res, &types.PropertyDefinitionFilter{})
+		}
+		// Now that we've expanded our partitions and object types, add in the
+		// original PropertyDefinitionFilter's Search and UsePrefix for each
+		// types.PropertyDefinitionFilter we've created
+		for _, pf := range res {
+			if filter.Key != "" {
+				op := types.OP_EQUAL
+				if filter.UsePrefix {
+					op = types.OP_GREATER_THAN_EQUAL
 				}
-			}
-		} else {
-			pf := &types.PropertyDefinitionFilter{
-				Key:       filter.Key,
-				UsePrefix: filter.UsePrefix,
+				pf.PropertyKey = &types.PropertyKeyCondition{
+					Op:          op,
+					PropertyKey: filter.Key,
+				}
 			}
 			if filter.Uuid != "" {
 				pf.Uuid = &types.UuidCondition{
@@ -174,7 +172,6 @@ func (s *Server) expandPropertyDefinitionFilter(
 					Uuid: filter.Uuid,
 				}
 			}
-			res = append(res, pf)
 		}
 	}
 	return res, nil

--- a/pkg/metadata/property_definition_filter.go
+++ b/pkg/metadata/property_definition_filter.go
@@ -12,7 +12,7 @@ import (
 func (s *Server) defaultPropertyDefinitionFilter(
 	session *pb.Session,
 ) (*types.PropertyDefinitionFilter, error) {
-	part, err := s.store.PartitionGet(session.Partition)
+	p, err := s.store.PartitionGet(session.Partition)
 	if err != nil {
 		if err == errors.ErrNotFound {
 			// Just return nil since clearly we can have no
@@ -27,7 +27,10 @@ func (s *Server) defaultPropertyDefinitionFilter(
 		return nil, err
 	}
 	return &types.PropertyDefinitionFilter{
-		Partition: part,
+		Partition: &types.PartitionCondition{
+			Op:        types.OP_EQUAL,
+			Partition: p,
+		},
 	}, nil
 }
 
@@ -105,14 +108,23 @@ func (s *Server) expandPropertyDefinitionFilter(
 		for _, p := range partitions {
 			if len(objTypes) == 0 {
 				f := &types.PropertyDefinitionFilter{
-					Partition: p,
+					Partition: &types.PartitionCondition{
+						Op:        types.OP_EQUAL,
+						Partition: p,
+					},
 				}
 				res = append(res, f)
 			} else {
 				for _, ot := range objTypes {
 					f := &types.PropertyDefinitionFilter{
-						Partition: p,
-						Type:      ot,
+						Partition: &types.PartitionCondition{
+							Op:        types.OP_EQUAL,
+							Partition: p,
+						},
+						ObjectType: &types.ObjectTypeCondition{
+							Op:         types.OP_EQUAL,
+							ObjectType: ot,
+						},
 					}
 					res = append(res, f)
 				}
@@ -121,7 +133,10 @@ func (s *Server) expandPropertyDefinitionFilter(
 	} else if len(objTypes) > 0 {
 		for _, ot := range objTypes {
 			f := &types.PropertyDefinitionFilter{
-				Type: ot,
+				ObjectType: &types.ObjectTypeCondition{
+					Op:         types.OP_EQUAL,
+					ObjectType: ot,
+				},
 			}
 			res = append(res, f)
 		}

--- a/pkg/metadata/storage/object.go
+++ b/pkg/metadata/storage/object.go
@@ -211,7 +211,7 @@ func (s *Store) objectsGetByFilter(
 		}
 		return []*pb.Object{obj}, nil
 	}
-	if filter.Search != "" {
+	if filter.Name != nil {
 		// OK, we were asked to search for one or more objects having a
 		// supplied name (optionally have the name as a prefix).
 		//
@@ -236,16 +236,16 @@ func (s *Store) objectsGetByFilter(
 						filter.Partition.Partition.Uuid,
 						filter.ObjectType.ObjectType.Code,
 						filter.Project,
-						filter.Search,
-						filter.UsePrefix,
+						filter.Name.Name,
+						filter.Name.Op != types.OP_EQUAL,
 					)
 				}
 			} else {
 				return s.objectsGetByNameIndex(
 					filter.Partition.Partition.Uuid,
 					filter.ObjectType.ObjectType.Code,
-					filter.Search,
-					filter.UsePrefix,
+					filter.Name.Name,
+					filter.Name.Op != types.OP_EQUAL,
 				)
 			}
 		}

--- a/pkg/metadata/storage/property_definition.go
+++ b/pkg/metadata/storage/property_definition.go
@@ -146,11 +146,10 @@ func (s *Store) PropertyDefinitionListWithReferences(
 	return res, nil
 }
 
-// propertyDefinitionsGetByFilter evaluates a single supplied
-// PropertyDefinitionFilter that has been populated with a valid Partition,
-// ObjectType and property key to filter by
+// propertyDefinitionsGetByFilter evaluates a single supplied matcher against
+// the known property definitions
 func (s *Store) propertyDefinitionsGetByFilter(
-	filter *types.PropertyDefinitionFilter,
+	matcher types.PropertyDefinitionMatcher,
 ) ([]*pb.PropertyDefinition, error) {
 	ctx, cancel := s.requestCtx()
 	defer cancel()
@@ -178,7 +177,7 @@ func (s *Store) propertyDefinitionsGetByFilter(
 		if err = proto.Unmarshal(kv.Value, obj); err != nil {
 			return nil, err
 		}
-		if !filter.Matches(obj) {
+		if !matcher.Matches(obj) {
 			continue
 		}
 		res[x] = obj

--- a/pkg/metadata/types/condition.go
+++ b/pkg/metadata/types/condition.go
@@ -115,3 +115,29 @@ func (c *PropertyKeyCondition) Matches(obj HasKey) bool {
 		return false
 	}
 }
+
+type HasName interface {
+	GetName() string
+}
+
+type NameCondition struct {
+	Op   Op
+	Name string
+}
+
+func (c *NameCondition) Matches(obj HasName) bool {
+	if c == nil || c.Name == "" {
+		return true
+	}
+	cmp := obj.GetName()
+	switch c.Op {
+	case OP_EQUAL:
+		return c.Name == cmp
+	case OP_NOT_EQUAL:
+		return c.Name != cmp
+	case OP_GREATER_THAN_EQUAL:
+		return strings.HasPrefix(cmp, c.Name)
+	default:
+		return false
+	}
+}

--- a/pkg/metadata/types/condition.go
+++ b/pkg/metadata/types/condition.go
@@ -61,3 +61,27 @@ func (c *ObjectTypeCondition) Matches(obj HasType) bool {
 		return false
 	}
 }
+
+type HasUuid interface {
+	GetUuid() string
+}
+
+type UuidCondition struct {
+	Op   Op
+	Uuid string
+}
+
+func (c *UuidCondition) Matches(obj HasUuid) bool {
+	if c == nil || c.Uuid == "" {
+		return true
+	}
+	cmp := obj.GetUuid()
+	switch c.Op {
+	case OP_EQUAL:
+		return c.Uuid == cmp
+	case OP_NOT_EQUAL:
+		return c.Uuid != cmp
+	default:
+		return false
+	}
+}

--- a/pkg/metadata/types/condition.go
+++ b/pkg/metadata/types/condition.go
@@ -1,0 +1,63 @@
+package types
+
+import pb "github.com/runmachine-io/runmachine/proto"
+
+type Op int
+
+const (
+	OP_EQUAL            Op = 0
+	OP_NOT_EQUAL           = 1
+	OP_GREAT_THAN          = 2
+	OP_GREAT_THAN_EQUAL    = 3
+	OP_LESS_THAN           = 4
+	OP_LESS_THAN_EQUAL     = 5
+)
+
+type HasPartition interface {
+	GetPartition() string
+}
+
+type PartitionCondition struct {
+	Op        Op
+	Partition *pb.Partition
+}
+
+func (c *PartitionCondition) Matches(obj HasPartition) bool {
+	if c == nil || c.Partition == nil {
+		return true
+	}
+	cmp := obj.GetPartition()
+	switch c.Op {
+	case OP_EQUAL:
+		return c.Partition.Uuid == cmp
+	case OP_NOT_EQUAL:
+		return c.Partition.Uuid != cmp
+	default:
+		return false
+	}
+}
+
+// TODO(jaypipes): Change this back to ObjectType
+type HasType interface {
+	GetType() string
+}
+
+type ObjectTypeCondition struct {
+	Op         Op
+	ObjectType *pb.ObjectType
+}
+
+func (c *ObjectTypeCondition) Matches(obj HasType) bool {
+	if c == nil || c.ObjectType == nil {
+		return true
+	}
+	cmp := obj.GetType()
+	switch c.Op {
+	case OP_EQUAL:
+		return c.ObjectType.Code == cmp
+	case OP_NOT_EQUAL:
+		return c.ObjectType.Code != cmp
+	default:
+		return false
+	}
+}

--- a/pkg/metadata/types/condition.go
+++ b/pkg/metadata/types/condition.go
@@ -1,16 +1,20 @@
 package types
 
-import pb "github.com/runmachine-io/runmachine/proto"
+import (
+	"strings"
+
+	pb "github.com/runmachine-io/runmachine/proto"
+)
 
 type Op int
 
 const (
-	OP_EQUAL            Op = 0
-	OP_NOT_EQUAL           = 1
-	OP_GREAT_THAN          = 2
-	OP_GREAT_THAN_EQUAL    = 3
-	OP_LESS_THAN           = 4
-	OP_LESS_THAN_EQUAL     = 5
+	OP_EQUAL              Op = 0
+	OP_NOT_EQUAL             = 1
+	OP_GREATER_THAN          = 2
+	OP_GREATER_THAN_EQUAL    = 3
+	OP_LESSER_THAN           = 4
+	OP_LESSER_THAN_EQUAL     = 5
 )
 
 type HasPartition interface {
@@ -81,6 +85,32 @@ func (c *UuidCondition) Matches(obj HasUuid) bool {
 		return c.Uuid == cmp
 	case OP_NOT_EQUAL:
 		return c.Uuid != cmp
+	default:
+		return false
+	}
+}
+
+type HasKey interface {
+	GetKey() string
+}
+
+type PropertyKeyCondition struct {
+	Op          Op
+	PropertyKey string
+}
+
+func (c *PropertyKeyCondition) Matches(obj HasKey) bool {
+	if c == nil || c.PropertyKey == "" {
+		return true
+	}
+	cmp := obj.GetKey()
+	switch c.Op {
+	case OP_EQUAL:
+		return c.PropertyKey == cmp
+	case OP_NOT_EQUAL:
+		return c.PropertyKey != cmp
+	case OP_GREATER_THAN_EQUAL:
+		return strings.HasPrefix(cmp, c.PropertyKey)
 	default:
 		return false
 	}

--- a/pkg/metadata/types/object.go
+++ b/pkg/metadata/types/object.go
@@ -3,38 +3,77 @@ package types
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/runmachine-io/runmachine/pkg/util"
 	pb "github.com/runmachine-io/runmachine/proto"
 )
+
+type ObjectMatcher interface {
+	Matches(obj *pb.Object) bool
+}
 
 // A specialized filter class that has already looked up specific partition and
 // object types (expanded from user-supplied partition and type filter
 // strings). Users pass pb.ObjectFilter messages which contain optional
 // pb.PartitionFilter and pb.ObjectTypeFilter messages. Those may be expanded
 // (due to UsePrefix = true) to a set of partition UUIDs and/or object type
-// codes. We then create zero or more of these ObjectListFilter structs
+// codes. We then create zero or more of these ObjectFilter structs
 // that represent a specific filter on partition UUID and object type, along
 // with the the object's name/UUID and UsePrefix flag.
-type ObjectListFilter struct {
-	Partition *pb.Partition
-	Type      *pb.ObjectType
-	Project   string
-	Search    string
-	UsePrefix bool
+type ObjectFilter struct {
+	Partition  *PartitionCondition
+	ObjectType *ObjectTypeCondition
+	Project    string
+	Search     string
+	UsePrefix  bool
 	// TODO(jaypipes): Add support for property and tag filters
 }
 
-func (f *ObjectListFilter) IsEmpty() bool {
-	return f.Partition == nil && f.Type == nil && f.Project == "" && f.Search == ""
+func (f *ObjectFilter) Matches(obj *pb.Object) bool {
+	if !f.Partition.Matches(obj) {
+		return false
+	}
+	if !f.ObjectType.Matches(obj) {
+		return false
+	}
+	if f.Project != "" && obj.Project != "" {
+		if obj.Project != f.Project {
+			return false
+		}
+	}
+	if f.Search != "" {
+		// TODO(jaypipes): Remove this when using UuidCondition
+		if util.IsUuidLike(f.Search) {
+			if obj.Uuid != util.NormalizeUuid(f.Search) {
+				return false
+			}
+		} else {
+			if f.UsePrefix {
+				if !strings.HasPrefix(obj.Name, f.Search) {
+					return false
+				}
+			} else {
+				if obj.Name != f.Search {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }
 
-func (f *ObjectListFilter) String() string {
+func (f *ObjectFilter) IsEmpty() bool {
+	return f.Partition == nil && f.ObjectType == nil && f.Project == "" && f.Search == ""
+}
+
+func (f *ObjectFilter) String() string {
 	attrMap := make(map[string]string, 0)
 	if f.Partition != nil {
-		attrMap["partition"] = f.Partition.Uuid
+		attrMap["partition"] = f.Partition.Partition.Uuid
 	}
-	if f.Type != nil {
-		attrMap["object_type"] = f.Type.Code
+	if f.ObjectType != nil {
+		attrMap["object_type"] = f.ObjectType.ObjectType.Code
 	}
 	if f.Project != "" {
 		attrMap["project"] = f.Project
@@ -51,7 +90,7 @@ func (f *ObjectListFilter) String() string {
 		}
 		attrs += k + "=" + v
 	}
-	return fmt.Sprintf("ObjectListFilter(%s)", attrs)
+	return fmt.Sprintf("ObjectFilter(%s)", attrs)
 }
 
 // ObjectWithReferences is a concrete struct containing pointers to

--- a/pkg/metadata/types/property_definition.go
+++ b/pkg/metadata/types/property_definition.go
@@ -25,16 +25,14 @@ type PropertyDefinitionMatcher interface {
 type PropertyDefinitionFilter struct {
 	Partition  *PartitionCondition
 	ObjectType *ObjectTypeCondition
-	Uuid       string
+	Uuid       *UuidCondition
 	Key        string
 	UsePrefix  bool
 }
 
 func (f *PropertyDefinitionFilter) Matches(obj *pb.PropertyDefinition) bool {
-	if f.Uuid != "" {
-		if f.Uuid != obj.Uuid {
-			return false
-		}
+	if !f.Uuid.Matches(obj) {
+		return false
 	}
 	if !f.Partition.Matches(obj) {
 		return false
@@ -57,7 +55,7 @@ func (f *PropertyDefinitionFilter) Matches(obj *pb.PropertyDefinition) bool {
 }
 
 func (f *PropertyDefinitionFilter) IsEmpty() bool {
-	return f.Partition == nil && f.ObjectType == nil && f.Key == "" && f.Uuid == ""
+	return f.Partition == nil && f.ObjectType == nil && f.Key == "" && f.Uuid == nil
 }
 
 func (f *PropertyDefinitionFilter) String() string {
@@ -68,8 +66,8 @@ func (f *PropertyDefinitionFilter) String() string {
 	if f.ObjectType != nil {
 		attrMap["object_type"] = f.ObjectType.ObjectType.Code
 	}
-	if f.Uuid != "" {
-		attrMap["uuid"] = f.Uuid
+	if f.Uuid != nil {
+		attrMap["uuid"] = f.Uuid.Uuid
 	}
 	if f.Key != "" {
 		attrMap["key"] = f.Key

--- a/proto/defs/object.proto
+++ b/proto/defs/object.proto
@@ -50,8 +50,9 @@ message ObjectFilter {
     // The project the object must belong to, if the object type scope of this
     // object is PROJECT
     string project = 3;
-    // A search term on the object's UUID or name
-    string search = 4;
-    // Indicates the search should be a prefix expression
-    bool use_prefix = 5;
+    string uuid = 4;
+    // A search term on the object's name
+    string name = 5;
+    // Indicates the search on name should be a prefix expression
+    bool use_prefix = 6;
 }


### PR DESCRIPTION
Overhauls the way that the filter objects are constructed and used inside the `runm-metadata`
service. Makes the filter objects use a Matches() interface and decomposes the filter objects
into Condition structs that individually solve a field match in the supplied object (either a
`PropertyDefinition` or `Object` struct).

Modifies the `runm $object get` CLI commands to be more intuitive. These commands now
may be called in one of two ways. The first way is by passing a UUID as a single argument.
The second way is to pass a single `--filter` CLI option containing a filter string.