### PR TITLE
plumb provider-create through to DB storage

### DIFF
--- a/cmd/runm/commands/provider.go
+++ b/cmd/runm/commands/provider.go
@@ -18,12 +18,13 @@ func init() {
 }
 
 func printProvider(obj *pb.Provider) {
-	fmt.Printf("Partition:   %s\n", obj.Partition)
+	fmt.Printf("Partition:     %s\n", obj.Partition)
 	fmt.Printf("Provider Type: %s\n", obj.ProviderType)
-	fmt.Printf("UUID:        %s\n", obj.Uuid)
-	fmt.Printf("Name:        %s\n", obj.Name)
+	fmt.Printf("UUID:          %s\n", obj.Uuid)
+	fmt.Printf("Name:          %s\n", obj.Name)
+	fmt.Printf("Generation:    %d\n", obj.Generation)
 	if obj.ParentUuid != "" {
-		fmt.Printf("Parent:     %s\n", obj.ParentUuid)
+		fmt.Printf("Parent:        %s\n", obj.ParentUuid)
 	}
 	// TODO(jaypipes): Add support for properties and tags
 	//if obj.Properties != nil {

--- a/cmd/runm/commands/provider_create.go
+++ b/cmd/runm/commands/provider_create.go
@@ -43,9 +43,10 @@ func providerCreate(cmd *cobra.Command, args []string) {
 	exitIfError(err)
 	obj := resp.Provider
 	if !quiet {
-		fmt.Printf("ok\n")
 		if verbose {
 			printProvider(obj)
+		} else {
+			fmt.Printf("%s\n", obj.Uuid)
 		}
 	}
 }

--- a/pkg/api/server/provider.go
+++ b/pkg/api/server/provider.go
@@ -5,8 +5,11 @@ import (
 
 	pb "github.com/runmachine-io/runmachine/pkg/api/proto"
 	"github.com/runmachine-io/runmachine/pkg/api/types"
+	"github.com/runmachine-io/runmachine/pkg/errors"
 	metapb "github.com/runmachine-io/runmachine/pkg/metadata/proto"
 	"github.com/runmachine-io/runmachine/pkg/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -29,7 +32,37 @@ func (s *Server) ProviderGet(
 			return nil, err
 		}
 	}
-	return s.providerGetByUuid(req.Session, search)
+	p, err := s.providerGetByUuid(req.Session, search)
+	if err != nil {
+		if err == errors.ErrNotFound {
+			return nil, ErrNotFound
+		}
+		s.log.ERR("failed getting provider with UUID %s: %s", search, err)
+		return nil, ErrUnknown
+	}
+	// Grab the object's name from the metadata service
+	name, err := s.nameFromUuid(req.Session, search)
+	if err != nil {
+		if err == errors.ErrNotFound {
+			s.log.ERR(
+				"DATA CORRUPTION! failed getting name for provider with "+
+					"UUID %s: object with UUID %s does not exist in metadata "+
+					"service but should exist",
+				search, err,
+			)
+			name = ""
+		} else {
+			s.log.ERR("failed getting provider with UUID %s: %s", search, err)
+			return nil, ErrUnknown
+		}
+	}
+	return &pb.Provider{
+		Partition:    p.Partition,
+		ProviderType: p.ProviderType,
+		Name:         name,
+		Uuid:         p.Uuid,
+		Generation:   p.Generation,
+	}, nil
 }
 
 // validateProviderCreateRequest ensures that the data the user sent in the
@@ -45,6 +78,18 @@ func (s *Server) validateProviderCreateRequest(
 	if err := p.Validate(); err != nil {
 		return nil, err
 	}
+
+	// Check that the supplied provider type exists
+	ptCode := p.ProviderType
+	_, err := s.providerTypeGetByCode(req.Session, ptCode)
+	if err != nil {
+		if err == errors.ErrNotFound {
+			return nil, errProviderTypeNotFound(ptCode)
+		}
+		s.log.ERR("failed checking provider type: %s", err)
+		return nil, ErrUnknown
+	}
+
 	return &p, nil
 }
 
@@ -85,6 +130,12 @@ func (s *Server) ProviderCreate(
 	}
 	createdObj, err := s.objectCreate(req.Session, provObj)
 	if err != nil {
+		if s, ok := status.FromError(err); ok {
+			scode := s.Code()
+			if scode == codes.FailedPrecondition || scode == codes.NotFound {
+				return nil, err
+			}
+		}
 		s.log.ERR(
 			"failed creating provider object in metadata service: %s",
 			err,
@@ -95,19 +146,24 @@ func (s *Server) ProviderCreate(
 	input.Uuid = createdObj.Uuid
 
 	// Next save the provider record in the resource service
-	var changed *pb.Provider
-	changed, err = s.providerCreate(req.Session, input)
+	resProv, err := s.providerCreate(req.Session, input)
 	if err != nil {
 		return nil, err
 	}
 	s.log.L1(
 		"created new provider with UUID %s in partition %s with name %s",
 		input.Uuid,
-		input.Partition,
+		createdObj.Partition,
 		input.Name,
 	)
 
 	return &pb.ProviderCreateResponse{
-		Provider: changed,
+		Provider: &pb.Provider{
+			Uuid:         input.Uuid,
+			Name:         input.Name,
+			Partition:    createdObj.Partition,
+			ProviderType: input.ProviderType,
+			Generation:   resProv.Generation,
+		},
 	}, nil
 }

--- a/pkg/api/types/provider.go
+++ b/pkg/api/types/provider.go
@@ -6,7 +6,8 @@ var (
 	// the set of valid provider type strings that may appear in the provider's
 	// "provider_type" field
 	ValidProviderTypes = []string{
-		"runm.compute_node",
+		"runm.compute",
+		"runm.storage.block",
 	}
 )
 

--- a/pkg/resource/proto/defs/provider.proto
+++ b/pkg/resource/proto/defs/provider.proto
@@ -6,12 +6,6 @@ import "capability.proto";
 import "distance.proto";
 import "wrappers.proto";
 
-// A type of provider -- e.g. a compute node, a NIC or a shared storage pool
-message ProviderType {
-    string code = 1;
-    StringValue description = 2;
-}
-
 // A collection of related providers
 message ProviderGroup {
     string uuid = 1;
@@ -30,9 +24,8 @@ message ProviderDistance {
 // and have capabilities associated with it.
 message Provider {
     string partition = 1;
-    ProviderType provider_type = 2;
+    string provider_type = 2;
     string uuid = 3;
-    string name = 4;
     Provider parent = 51;
     Provider root = 52;
     repeated ProviderGroup groups = 53;

--- a/pkg/resource/server/errors.go
+++ b/pkg/resource/server/errors.go
@@ -78,6 +78,10 @@ var (
 		codes.FailedPrecondition,
 		"Either UUID or name to search for is required.",
 	)
+	ErrUuidRequired = status.Errorf(
+		codes.FailedPrecondition,
+		"A UUID is required.",
+	)
 	ErrCodeRequired = status.Errorf(
 		codes.FailedPrecondition,
 		"A code to search for is required.",

--- a/pkg/resource/server/storage/provider.go
+++ b/pkg/resource/server/storage/provider.go
@@ -1,8 +1,11 @@
 package storage
 
 import (
-	"fmt"
+	"database/sql"
+	"log"
 
+	"github.com/go-sql-driver/mysql"
+	"github.com/runmachine-io/runmachine/pkg/errors"
 	pb "github.com/runmachine-io/runmachine/pkg/resource/proto"
 )
 
@@ -10,12 +13,6 @@ type ProviderRecord struct {
 	Provider *pb.Provider
 	ID       int64
 }
-
-var (
-	ErrUnknown   = fmt.Errorf("An unknown error occurred.")
-	ErrDuplicate = fmt.Errorf("Record already exists.")
-	ErrNotFound  = fmt.Errorf("No such record.")
-)
 
 // providerExists returns true if a provider with the UUID exists, false
 // otherwise
@@ -32,38 +29,128 @@ func (s *Store) ProviderGetByUuid(
 ) (*ProviderRecord, error) {
 	qs := `SELECT
   p.id
+, part.uuid AS partition_uuid
 , pt.code AS provider_type
 , p.generation
 FROM providers AS p
 JOIN provider_types AS pt
  ON p.provider_type_id = pt.id
+JOIN partitions AS part
+ ON p.partition_id = part.id
 WHERE p.uuid = ?`
-	qargs := []interface{}{uuid}
-	rows, err := s.db.Query(qs, qargs...)
-	if err != nil {
-		return nil, err
-	}
-	err = rows.Err()
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
 	rec := &ProviderRecord{
 		Provider: &pb.Provider{
 			Uuid: uuid,
 		},
 	}
-	for rows.Next() {
-		err = rows.Scan(
-			&rec.ID,
-			&rec.Provider.ProviderType,
-			&rec.Provider.Generation,
-		)
-		if err != nil {
-			return nil, err
-		}
+	err := s.DB().QueryRow(qs, uuid).Scan(
+		&rec.ID,
+		&rec.Provider.Partition,
+		&rec.Provider.ProviderType,
+		&rec.Provider.Generation,
+	)
+	switch {
+	case err == sql.ErrNoRows:
+		return nil, errors.ErrNotFound
+	case err != nil:
+		log.Fatal(err)
 	}
 	return rec, nil
+}
+
+// ensurePartition creates a record in the partitions table for the supplied
+// partition UUID if no such record exists and returns the newly-inserted
+// partition record's internal identifier. If a partition record already exists
+// for the UUID, the function just returns the internal identifier.
+func (s *Store) ensurePartition(
+	uuid string,
+) (int64, error) {
+	var id int64
+	db := s.DB()
+	qs := "SELECT id FROM partitions WHERE uuid = ?"
+	err := db.QueryRow(qs, uuid).Scan(&id)
+	switch {
+	case err == sql.ErrNoRows:
+		// New record. Create it and return the newly-created internal ID
+		qs = "INSERT INTO partitions (uuid) VALUES (?)"
+		res, err := db.Exec(qs, uuid)
+		if err != nil {
+			me, ok := err.(*mysql.MySQLError)
+			if !ok {
+				s.log.ERR("failed converting err to mysql.MYSQLError: %s", err)
+				return 0, err
+			}
+			if me.Number == 1062 {
+				// Another thread already inserted this partition, so just grab
+				// the partition's internal ID
+				qs := "SELECT id FROM partitions WHERE uuid = ?"
+				err := db.QueryRow(qs, uuid).Scan(&id)
+				if err != nil {
+					s.log.ERR(
+						"failed getting partition internal ID: %s",
+						err,
+					)
+					return 0, err
+				}
+				return id, nil
+			}
+			s.log.ERR("failed getting partition internal ID: %s", me)
+			return 0, err
+		}
+		s.log.L2("created new partitions record for UUID %s", uuid)
+		return res.LastInsertId()
+	case err != nil:
+		return 0, err
+	}
+	return id, nil
+}
+
+// ensureProviderType creates a record in the provider_types table for the
+// supplied provider_type code if no such record exists and returns the
+// newly-inserted provider_type record's internal identifier. If a
+// provider_type record already exists for the code, the function just returns
+// the internal identifier.
+func (s *Store) ensureProviderType(
+	code string,
+) (int64, error) {
+	var id int64
+	db := s.DB()
+	qs := "SELECT id FROM provider_types WHERE code = ?"
+	err := db.QueryRow(qs, code).Scan(&id)
+	switch {
+	case err == sql.ErrNoRows:
+		// New record. Create it and return the newly-created internal ID
+		qs = "INSERT INTO provider_types (code) VALUES (?)"
+		res, err := db.Exec(qs, code)
+		if err != nil {
+			me, ok := err.(*mysql.MySQLError)
+			if !ok {
+				s.log.ERR("failed converting err to mysql.MYSQLError: %s", err)
+				return 0, err
+			}
+			if me.Number == 1062 {
+				// Another thread already inserted this provider_type, so just grab
+				// the provider_type's internal ID
+				qs := "SELECT id FROM provider_types WHERE code = ?"
+				err := db.QueryRow(qs, code).Scan(&id)
+				if err != nil {
+					s.log.ERR(
+						"failed getting provider_type internal ID: %s",
+						err,
+					)
+					return 0, err
+				}
+				return id, nil
+			}
+			s.log.ERR("failed getting provider_type internal ID: %s", me)
+			return 0, err
+		}
+		s.log.L2("created new provider_types record for code %s", code)
+		return res.LastInsertId()
+	case err != nil:
+		return 0, err
+	}
+	return id, nil
 }
 
 // ProviderCreate creates the provider record in backend storage and returns a
@@ -74,38 +161,49 @@ func (s *Store) ProviderCreate(
 	exists, err := s.providerExists(prov.Uuid)
 	if err != nil {
 		s.log.ERR("failed looking up provider by UUID: %s", err)
-		return nil, ErrUnknown
+		return nil, errors.ErrUnknown
 	}
 	if exists {
-		return nil, ErrDuplicate
+		return nil, errors.ErrDuplicate
 	}
 
-	tx, err := s.db.Begin()
+	// Grab the internal IDs of the new provider's partition and provider type,
+	// ensuring that records exist for the partition and provider type.
+	partId, err := s.ensurePartition(prov.Partition)
+	if err != nil {
+		return nil, errors.ErrUnknown
+	}
+	ptId, err := s.ensureProviderType(prov.ProviderType)
+	if err != nil {
+		return nil, errors.ErrUnknown
+	}
+
+	tx, err := s.DB().Begin()
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
-	qargs := []interface{}{
-		prov.Uuid,
-		prov.ProviderType,
-		1, // generation
-	}
-
 	qs := `
 INSERT INTO providers (
   uuid
 , provider_type_id
+, partition_id
 , generation
-) VALUES (?, ?, ?)
+) VALUES (?, ?, ?, ?)
 `
-
 	stmt, err := tx.Prepare(qs)
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
-	res, err := stmt.Exec(qargs...)
+
+	res, err := stmt.Exec(
+		prov.Uuid,
+		ptId,
+		partId,
+		1, // generation
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/server/storage/store.go
+++ b/pkg/resource/server/storage/store.go
@@ -22,12 +22,12 @@ func (s *Store) Close() {
 	}
 }
 
-// DB returns a handle to a SQL database. The forceNew parameter indicates that
+// getDB returns a handle to a SQL database. The forceNew parameter indicates that
 // a new DB handle will always be created even if the cached DB handle for the
 // Store is not nil. The unsafe parameter indicates that the returned DB handle
 // will have connections that accept multiple statements. If unsafe is true,
 // the Store's cached DB handle is not returned.
-func (s *Store) DB(forceNew bool, unsafe bool) (*sql.DB, error) {
+func (s *Store) getDB(forceNew bool, unsafe bool) (*sql.DB, error) {
 	if !unsafe && !forceNew && s.db != nil {
 		return s.db, nil
 	}
@@ -48,6 +48,15 @@ func (s *Store) DB(forceNew bool, unsafe bool) (*sql.DB, error) {
 		return nil, err
 	}
 	return db, nil
+}
+
+func (s *Store) DB() *sql.DB {
+	db, err := s.getDB(false, false)
+	if err != nil {
+		// TODO(jaypipes): Perform retry with backoff
+		panic("failed to get normal DB handle!")
+	}
+	return db
 }
 
 func New(log *logging.Logs, cfg *config.Config) (*Store, error) {

--- a/tests/data/objects/runm.provider.yaml
+++ b/tests/data/objects/runm.provider.yaml
@@ -1,5 +1,5 @@
 partition: part0
-provider_type: runm.compute_node
+provider_type: runm.compute
 name: row1-rack1-compute23
 tags:
   - compute


### PR DESCRIPTION
This patch adds the final pieces to the provider-create workflow,
creating the provider record in the resource service's DB storage as
well as ensuring internal partitions and provider_types records are
created as needed.

The `runm provider create` command now works properly:

```
$ runm provider create -f tests/data/objects/runm.provider.yaml
3fa6d3cb3e3c414abbcd87b27d7d3fde
$ runm provider get 3fa6d3cb3e3c414abbcd87b27d7d3fde
Partition:     part0
Provider Type: runm.compute
UUID:          3fa6d3cb3e3c414abbcd87b27d7d3fde
Name:          row1-rack1-compute23
Generation:    1
$ runm provider get
row1-rack1-compute23
Partition:     part0
Provider Type: runm.compute
UUID:          3fa6d3cb3e3c414abbcd87b27d7d3fde
Name:          row1-rack1-compute23
Generation:    1
```

Issue #89