### PR TITLE
support properties and tags for provider

### DIFF
--- a/cmd/runm/commands/provider.go
+++ b/cmd/runm/commands/provider.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
 	pb "github.com/runmachine-io/runmachine/pkg/api/proto"
 	"github.com/spf13/cobra"
@@ -26,15 +27,14 @@ func printProvider(obj *pb.Provider) {
 	if obj.ParentUuid != "" {
 		fmt.Printf("Parent:        %s\n", obj.ParentUuid)
 	}
-	// TODO(jaypipes): Add support for properties and tags
-	//if obj.Properties != nil {
-	//	fmt.Printf("Properties:\n")
-	//	for _, prop := range obj.Properties {
-	//		fmt.Printf("   %s=%s\n", prop.Key, prop.Value)
-	//	}
-	//}
-	//if obj.Tags != nil {
-	//	tags := strings.Join(obj.Tags, ",")
-	//	fmt.Printf("Tags:        %s\n", tags)
-	//}
+	if obj.Properties != nil {
+		fmt.Printf("Properties:\n")
+		for _, prop := range obj.Properties {
+			fmt.Printf("   %s=%s\n", prop.Key, prop.Value)
+		}
+	}
+	if obj.Tags != nil {
+		tags := strings.Join(obj.Tags, ",")
+		fmt.Printf("Tags:        %s\n", tags)
+	}
 }

--- a/pkg/api/proto/defs/property.proto
+++ b/pkg/api/proto/defs/property.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package runmapi;
+
+message Property {
+    string key = 1;
+    string value = 2;
+}

--- a/pkg/api/proto/defs/provider.proto
+++ b/pkg/api/proto/defs/provider.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package runmapi;
 
+import "property.proto";
+
 // A provider exposes inventory of resources to be claimed by consumers of
 // those resources. Each provider may belong to zero or more provider groups
 // and have capabilities associated with it.
@@ -11,8 +13,11 @@ message Provider {
     string uuid = 3;
     string name = 4;
     string parent_uuid = 5;
+    repeated Property properties = 50;
+    repeated string tags = 51;
     uint32 generation = 100;
 }
+
 
 // Used in matching provider records
 message ProviderFilter {

--- a/tests/data/objects/runm.provider.yaml
+++ b/tests/data/objects/runm.provider.yaml
@@ -1,5 +1,9 @@
 partition: part0
 provider_type: runm.compute
 name: row1-rack1-compute23
+properties:
+  location.row: 1
+  location.rack: 1
+  location.rack_position: 23
 tags:
   - compute


### PR DESCRIPTION
Adds support for adding properties and tags to a provider and displaying
those properties/tags in the `runm provider get` command:

```
$ cat tests/data/objects/runm.provider.yaml
partition: part0
provider_type: runm.compute
name: row1-rack1-compute23
properties:
  location.row: 1
  location.rack: 1
  location.rack_position: 23
tags:
  - compute
$ runm provider create -f tests/data/objects/runm.provider.yaml
84fa77ad736d4dbba82c8456afd6f92f
$ runm provider get 84fa77ad736d4dbba82c8456afd6f92f
Partition:     part0
Provider Type: runm.compute
UUID:          84fa77ad736d4dbba82c8456afd6f92f
Name:          row1-rack1-compute23
Generation:    1
Properties:
   location.row=1
   location.rack=1
   location.rack_position=23
Tags:        compute
```

Issue #89