### PR TITLE
route partition filter down to resource service

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -20,6 +20,11 @@ var (
 		Code:     400,
 		Message:  "bad input",
 	}
+	ErrInvalidPartitionFormat = &Error{
+		HTTPCode: 400,
+		Code:     400002,
+		Message:  "partition must be a UUID",
+	}
 	ErrNotFound = &Error{
 		HTTPCode: 404,
 		Code:     404,


### PR DESCRIPTION
Completes the filter pushdown of partition filters to the resource
service when listing providers. We keep a cache of partition UUIDs for
each request filter in the API service's PartitionList method. When
constructing the more concrete UuidFilter for provider partition UUIDs
in the resource service's PartitionList API call, we grab the cached
list of partition UUIDs that was normalized when calling the metadata
service.

Filtering by partition name now works properly:

```
$ runm partition create -f tests/data/objects/runm.partition.yaml
cfe73d38092b408fbffab16dd37aac96
$ runm provider create -f tests/data/objects/runm.provider.yaml
31832c1efe0344938fbf8aa9c1d70230
$ runm provider list
+----------------------------------+---------------+----------------------------------+----------------------+
|            PARTITION             | PROVIDER TYPE |               UUID               |         NAME         |
+----------------------------------+---------------+----------------------------------+----------------------+
| cfe73d38092b408fbffab16dd37aac96 | runm.compute  | 31832c1efe0344938fbf8aa9c1d70230 | row1-rack1-compute23 |
+----------------------------------+---------------+----------------------------------+----------------------+
$ runm provider list --filter "partition=part0"
+----------------------------------+---------------+----------------------------------+----------------------+
|            PARTITION             | PROVIDER TYPE |               UUID               |         NAME         |
+----------------------------------+---------------+----------------------------------+----------------------+
| cfe73d38092b408fbffab16dd37aac96 | runm.compute  | 31832c1efe0344938fbf8aa9c1d70230 | row1-rack1-compute23 |
+----------------------------------+---------------+----------------------------------+----------------------+
$ runm provider list --filter "partition=part1"
No records found matching search criteria.
```

Issue #89