### PR TITLE
implement `runm provider definition get`

### DIFF
--- a/cmd/runm/commands/provider_definition.go
+++ b/cmd/runm/commands/provider_definition.go
@@ -21,6 +21,7 @@ var providerDefinitionCommand = &cobra.Command{
 }
 
 func init() {
+	providerDefinitionCommand.AddCommand(providerDefinitionGetCommand)
 	providerDefinitionCommand.AddCommand(providerDefinitionSetCommand)
 }
 
@@ -60,7 +61,7 @@ func printPropertyPermission(obj *pb.PropertyPermission) {
 }
 
 func printProviderDefinition(obj *pb.ProviderDefinition) {
-	fmt.Printf("Partition:    %s\n", obj.Partition)
+	fmt.Printf("Partition: %s\n", obj.Partition)
 	fmt.Printf("Schema:\n%s", obj.Schema)
 	if len(obj.PropertyPermissions) > 0 {
 		fmt.Printf("Property permissions:\n")

--- a/cmd/runm/commands/provider_definition_get.go
+++ b/cmd/runm/commands/provider_definition_get.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+
+	pb "github.com/runmachine-io/runmachine/pkg/api/proto"
+)
+
+const (
+	usageProviderDefinitionGet = `Show information for a provider definition
+
+Specify a single CLI argument with the UUID or name of the partition you wish
+to show the provider definition for:
+
+  runm provider definition get 4f4f54c9bfb44cce9a02d4daf6f79ea3
+
+or
+
+  runm provider definition get part0
+`
+)
+
+var providerDefinitionGetCommand = &cobra.Command{
+	Use:   "get <search>",
+	Short: "Show information for a provider definition",
+	Run:   providerDefinitionGet,
+	Long:  usageProviderDefinitionGet,
+}
+
+func providerDefinitionGet(cmd *cobra.Command, args []string) {
+	conn := apiConnect()
+	defer conn.Close()
+
+	client := pb.NewRunmAPIClient(conn)
+
+	session := apiGetSession()
+
+	var filter *pb.ProviderDefinitionFilter
+
+	if len(args) != 1 {
+		fmt.Fprintf(
+			os.Stderr,
+			"Error: please provide a single argument: either specify a UUID "+
+				"or a name for the partition whose provider definition you "+
+				"wish to show\n",
+		)
+		cmd.Help()
+		os.Exit(1)
+	}
+
+	filter = &pb.ProviderDefinitionFilter{
+		PartitionFilter: &pb.SearchFilter{
+			Search:    args[0],
+			UsePrefix: false,
+		},
+	}
+	obj, err := client.ProviderDefinitionGet(
+		context.Background(),
+		&pb.ProviderDefinitionGetRequest{
+			Session: session,
+			Filter:  filter,
+		},
+	)
+	exitIfError(err)
+	printProviderDefinition(obj)
+}

--- a/pkg/api/proto/defs/provider.proto
+++ b/pkg/api/proto/defs/provider.proto
@@ -23,7 +23,7 @@ message Provider {
 message ProviderFilter {
     // UUID or human-readable name of the provider
     SearchFilter primary_filter = 1;
-    // UUID or human-readable name of the provider's partition
+    // UUID or human-readable name of the partition
     SearchFilter partition_filter = 2;
     // Type of the provider
     SearchFilter provider_type_filter = 3;
@@ -40,4 +40,12 @@ message ProviderDefinition {
     string schema = 2;
     // The set of permissions to apply on properties
     repeated PropertyPermissions property_permissions = 50;
+}
+
+// Used in matching provider definition records
+message ProviderDefinitionFilter {
+    // UUID or human-readable name of the partition
+    SearchFilter partition_filter = 2;
+    // Type of the provider
+    SearchFilter provider_type_filter = 3;
 }

--- a/pkg/api/proto/defs/service.proto
+++ b/pkg/api/proto/defs/service.proto
@@ -28,6 +28,10 @@ service RunmAPI {
     rpc provider_type_list(ProviderTypeListRequest) returns (
         stream ProviderType) {}
 
+    // Returns information about a specific provider definition
+    rpc provider_definition_get(ProviderDefinitionGetRequest) returns (
+        ProviderDefinition) {}
+
     // Defines a schema for providers in a partition
     rpc provider_definition_set(CreateRequest) returns (
         ProviderDefinitionSetResponse) {}
@@ -89,6 +93,11 @@ message ProviderTypeListRequest {
     Session session = 1;
     SearchOptions options = 2;
     repeated ProviderTypeFilter any = 3;
+}
+
+message ProviderDefinitionGetRequest {
+    Session session = 1;
+    ProviderDefinitionFilter filter = 2;
 }
 
 message ProviderDefinitionSetResponse {

--- a/pkg/api/types/provider_definition.go
+++ b/pkg/api/types/provider_definition.go
@@ -13,8 +13,7 @@ var (
 		"partition",
 		"provider_type",
 	}
-	providerSchemaTemplateContents = `
-{
+	providerSchemaTemplateContents = `{
   "$id": "https://runmachine.io/runm.provider.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "A provider of resources",
@@ -55,7 +54,7 @@ var (
         }
       },
       "required": [{{ quote_join .RequiredProperties ", " }}],
-	  "additionalProperties": false
+      "additionalProperties": false
     }
   },
   "required": [{{ quote_join .RequiredFields ", " }}],


### PR DESCRIPTION
Allows an administrator to show the provider definition set for a
partition:

```
$ runm provider definition get part0
Partition: 59105488cb214258b7b38ec376e3be7f
Schema:
{
  "$id": "https://runmachine.io/runm.provider.schema.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "description": "A provider of resources",
  "type": "object",
  "properties": {
    "partition": {
      "type": "string"
    },
    "provider_type": {
      "type": "string"
    },
    "name": {
      "type": "string"
    },
    "uuid": {
      "type": "string"
    },
    "parent": {
      "type": "string"
    },
    "tags": {
      "type": "array",
      "items": {
        "type": "string"
      }
    },
    "properties": {
      "type": "object",
      "properties": {
        "location.site": {
          "type": ["string"]
        },
        "location.row": {
          "type": ["integer"]
        },
        "location.rack": {
          "type": ["integer"]
        },
        "location.rack_position": {
          "type": ["integer"]
        }
      },
      "patternProperties": {
        "^[a-zA-Z0-9]*$": {
          "type": "string"
        }
      },
      "required": ["location.site", "location.row", "location.rack", "location.rack_position"],
      "additionalProperties": false
    }
  },
  "required": ["partition", "provider_type"],
  "additionalProperties": false
}
Property permissions:
  Key: location.site
    0: PROJECT(proj0) READ/WRITE
  Key: location.row
    0: PROJECT(proj0) READ/WRITE
  Key: location.rack
    0: PROJECT(proj0) READ/WRITE
  Key: location.rack_position
    0: PROJECT(proj0) READ/WRITE
```

Issue #100