### PR TITLE
use github.com/ghodss/yaml

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -28,6 +28,12 @@
   version = "v1.1.1"
 
 [[projects]]
+  name = "github.com/ghodss/yaml"
+  packages = ["."]
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
   revision = "72cd26f257d44c1114970e19afddcd812016007e"
@@ -241,6 +247,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "73f8b55fd232011bda1d8afd2e8aef1c3dfc5d2e785b96ee71b6e4bb908cd904"
+  inputs-digest = "d8922aecdda4d6d8e114587d4d769507b1573aae165b6e19487f44ee614f3d91"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -78,13 +78,13 @@
   version = "1.2.2"
 
 [[constraint]]
-  name = "gopkg.in/yaml.v2"
-  version = "2.2.1"
-
-[[constraint]]
   name = "github.com/go-sql-driver/mysql"
   version = "1.4.1"
 
 [[constraint]]
   name = "github.com/xeipuuv/gojsonschema"
   version = "1.1.0"
+
+[[constraint]]
+  name = "github.com/ghodss/yaml"
+  version = "1.0.0"

--- a/pkg/api/server/partition.go
+++ b/pkg/api/server/partition.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"io"
 
+	"github.com/ghodss/yaml"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	yaml "gopkg.in/yaml.v2"
 
 	pb "github.com/runmachine-io/runmachine/pkg/api/proto"
 	"github.com/runmachine-io/runmachine/pkg/api/types"

--- a/pkg/api/server/provider.go
+++ b/pkg/api/server/provider.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ghodss/yaml"
 	"github.com/xeipuuv/gojsonschema"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	yaml "gopkg.in/yaml.v2"
 
 	pb "github.com/runmachine-io/runmachine/pkg/api/proto"
 	"github.com/runmachine-io/runmachine/pkg/api/types"

--- a/pkg/api/server/provider_definition.go
+++ b/pkg/api/server/provider_definition.go
@@ -3,7 +3,7 @@ package server
 import (
 	"context"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 
 	pb "github.com/runmachine-io/runmachine/pkg/api/proto"
 	"github.com/runmachine-io/runmachine/pkg/api/types"

--- a/pkg/api/types/partition.go
+++ b/pkg/api/types/partition.go
@@ -5,10 +5,10 @@ import "fmt"
 type Partition struct {
 	// The UUID of the partition. Expected to be blank when a user is creating a
 	// new partition.
-	Uuid string `yaml:"uuid"`
+	Uuid string `json:"uuid,omitempty"`
 	// Human-readable name for the partition. Uniqueness is guaranteed in the
 	// scope of the runmachine deployment
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 }
 
 // Validate returns an error if the definition is invalid, nil otherwise

--- a/pkg/api/types/property_definition.go
+++ b/pkg/api/types/property_definition.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -71,11 +72,11 @@ var (
 type PropertyDefinition struct {
 	// JSONSchema property type document represented in YAML, dictating the
 	// constraints applied by this schema to the property's value
-	Schema *PropertySchema `yaml:"schema"`
+	Schema *PropertySchema `json:"schema"`
 	// Indicates the property is required for all objects of this object type
-	Required bool `yaml:"required"`
+	Required bool `json:"required"`
 	// Set of project/role specific permissions for the property
-	Permissions []*PropertyPermission `yaml:"permissions"`
+	Permissions []*PropertyPermission `json:"permissions"`
 }
 
 // Validate returns an error if the definition is invalid, nil otherwise
@@ -92,9 +93,9 @@ func (def *PropertyDefinition) Validate() error {
 // to read or write a property on an object
 type PropertyPermission struct {
 	// Optional project identifier to control access for
-	Project string `yaml:"project"`
+	Project string `json:"project,omitempty"`
 	// Optional role identifier to control access for
-	Role string `yaml:"role"`
+	Role string `json:"role,omitempty"`
 	// A string containing the permissions:
 	//
 	// "" indicates the project/role should have no read or write access to the
@@ -102,7 +103,7 @@ type PropertyPermission struct {
 	// "r" indicates the project/role should have read access
 	// "w" indicates the project/role should have write access
 	// "rw" indicates the project/role should have read and write access
-	Permission string `yaml:"permission"`
+	Permission string `json:"permission"`
 }
 
 // Validate returns an error if the permission is invalid, nil otherwise
@@ -139,17 +140,17 @@ func (perm *PropertyPermission) PermissionUint32() uint32 {
 	}
 }
 
-// NOTE(jaypipes): A type that can be represented in YAML as *either* a string
+// NOTE(jaypipes): A type that can be represented in JSON as *either* a string
 // *or* an array of strings, which is what JSONSchema's type field needs.
 // see: https://github.com/go-yaml/yaml/issues/100
 type StringArray []string
 
-func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (a *StringArray) UnmarshalJSON(b []byte) error {
 	var multi []string
-	err := unmarshal(&multi)
+	err := json.Unmarshal(b, &multi)
 	if err != nil {
 		var single string
-		err := unmarshal(&single)
+		err := json.Unmarshal(b, &single)
 		if err != nil {
 			return err
 		}
@@ -162,29 +163,29 @@ func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 type PropertySchema struct {
 	// May only be a JSON scalar type (string, integer, number, etc)
-	Types StringArray `yaml:"type"`
+	Types StringArray `json:"type"`
 	// Property value must be one of these enumerated list of values. If this
 	// exists in the schema document and no types are specified, type is
 	// assumed to be string
-	Enum []string `yaml:"enum"`
+	Enum []string `json:"enum,omitempty"`
 	// Indicates the property's value must be a multiple of this number. The
 	// property's type must be either "number" or "integer"
-	MultipleOf *uint `yaml:"multiple_of"`
+	MultipleOf *uint `json:"multiple_of,omitempty"`
 	// Indicates the property's numeric value must be greater than or equal to
 	// this number The property's type must be either "number" or "integer"
-	Minimum *int `yaml:"minimum"`
+	Minimum *int `json:"minimum,omitempty"`
 	// Indicates the property's numeric value must be less than or equal to
 	// this number The property's type must be either "number" or "integer"
-	Maximum *int `yaml:"maximum"`
+	Maximum *int `json:"maximum,omitempty"`
 	// Indicates the property's value must be a string and that string must
 	// have a length greater than or equal to this number
-	MinLength *uint `yaml:"min_length"`
+	MinLength *uint `json:"min_length,omitempty"`
 	// Indicates the property's value must be a string and that string must
 	// have a length less than or equal to this number
-	MaxLength *uint `yaml:"max_length"`
+	MaxLength *uint `json:"max_length,omitempty"`
 	// Indicates the property's value must be a string and must match this
 	// regex pattern
-	Pattern string `yaml:"pattern"`
+	Pattern string `json:"pattern,omitempty"`
 	// A pre-defined regex that will validate the incoming property value.
 	// Possible string values for "format" are:
 	//
@@ -202,7 +203,7 @@ type PropertySchema struct {
 	// * "iri"
 	// * "iri-reference"
 	// * "uri-template"
-	Format string `yaml:"format"`
+	Format string `json:"format"`
 }
 
 type propertySchemaWithKey struct {

--- a/pkg/api/types/property_definition_test.go
+++ b/pkg/api/types/property_definition_test.go
@@ -3,8 +3,8 @@ package types_test
 import (
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
-	yaml "gopkg.in/yaml.v2"
 
 	"github.com/runmachine-io/runmachine/pkg/api/types"
 )

--- a/pkg/api/types/provider.go
+++ b/pkg/api/types/provider.go
@@ -15,24 +15,24 @@ var (
 // has a set of capabilities
 type Provider struct {
 	// Identifier of the partition the object belongs to
-	Partition string `yaml:"partition" json:"partition"`
+	Partition string `json:"partition"`
 	// Code for the type of provider this is
-	ProviderType string `yaml:"provider_type" json:"provider_type"`
+	ProviderType string `json:"provider_type"`
 	// Optional identifier of the provider the provider is a child of. Leave
 	// empty if the provider has no parents (it's a "root provider")
-	Parent string `yaml:"parent" json:"parent,omitempty"`
+	Parent string `json:"parent,omitempty"`
 	// The UUID of the provider. Expected to be blank when a user is creating a
 	// new provider.
-	Uuid string `yaml:"uuid" json:"uuid,omitempty"`
+	Uuid string `json:"uuid,omitempty"`
 	// Human-readable name for the provider. Uniqueness is guaranteed in the
 	// scope of the partition the provider belongs to.
-	Name string `yaml:"name" json:"name"`
+	Name string `json:"name"`
 	// Map of key/value properties associated with this provider. Properties can
 	// have a structure and be validated against a schema.
-	Properties map[string]interface{} `yaml:"properties" json:"properties,omitempty"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
 	// Array of string tags. Tags are unstructured and unvalidated and any user
 	// with write access to the provider can add or remove any tag.
-	Tags []string `yaml:"tags" json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 }
 
 // Validate returns an error if the definition is invalid, nil otherwise

--- a/pkg/api/types/provider_definition.go
+++ b/pkg/api/types/provider_definition.go
@@ -107,7 +107,7 @@ type ProviderDefinition struct {
 	// Named properties may have their values constrained by a property
 	// definition. The map key is the key of the property to apply the
 	// property definition to
-	PropertyDefinitions map[string]*PropertyDefinition `yaml:"property_definitions"`
+	PropertyDefinitions map[string]*PropertyDefinition `json:"property_definitions"`
 }
 
 // Validate returns an error if the definition is invalid, nil otherwise


### PR DESCRIPTION
Replaces the direct use of gopkg.in/yaml.v2 with the
github.com/ghodss/yaml package. This new package is useful for
correcting marshaling problems with the gopkg.in/yaml.v2 code and allows
us to simplify JSON and YAML parsing and serialization so that we can
eventually only decoarate the protobuffer files with `json:XXX`
annotations and will not need to use `yaml:XXX` annotations on custom
structs in pkg/api/types.

Issue #113