### PR TITLE
properly instantiate Provider struct for Scan

### DIFF
--- a/pkg/resource/server/storage/provider.go
+++ b/pkg/resource/server/storage/provider.go
@@ -67,13 +67,15 @@ JOIN partitions AS part
 WHERE p.uuid = ?`
 	rec := &ProviderRecord{
 		Provider: &pb.Provider{
-			Uuid: uuid,
+			Uuid:         uuid,
+			Partition:    &pb.Partition{},
+			ProviderType: &pb.ProviderType{},
 		},
 	}
 	err := s.DB().QueryRow(qs, uuid).Scan(
 		&rec.ID,
-		&rec.Provider.Partition,
-		&rec.Provider.ProviderType,
+		&rec.Provider.Partition.Uuid,
+		&rec.Provider.ProviderType.Code,
 		&rec.Provider.Generation,
 	)
 	switch {


### PR DESCRIPTION
When consolidating the Provider protobuffer representations for the API
server and resource server, I failed to properly instantiate the
Provider.Partition and Provider.ProviderType sub-struct fields when
Scan'ing from the SQL result. This was leading to a panic in the
resource service and an unknown error being returned to the API service.

Fixes Issue #121