### PR TITLE
build runm client outside of Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-tests/poc/venv
+build/bin/
 
 # Don't store vendored code in tree
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PROTO := proto
 VENDOR := vendor
 VERSION := $(shell git describe --tags --always --dirty)
+BUILD_DIR := $(shell pwd)/build
 PROTO_DIR := $(shell pwd)/proto
 PROTO_DEFS_DIR := $(shell pwd)/proto/defs
 GO_BIN_DIR := $(GOPATH)/bin
@@ -70,9 +71,9 @@ build-api: build-base
 	@echo "building runm-api Docker image ..."
 	docker build -q --label built-by=runmachine.io -t runm/api:$(VERSION) . -f cmd/runm-api/Dockerfile
 
-build-cli: build-base
-	@echo "building runm CLI Docker image ..."
-	docker build -q --label built-by=runmachine.io -t runm/runm:$(VERSION) . -f cmd/runm/Dockerfile
+build-cli:
+	@echo "building runm CLI Docker image to $(BUILD_BIN_DIR)/runm ..."
+	bash $(BUILD_DIR)/build_runm.sh
 
 build: build-base build-metadata build-resource build-api build-cli
 

--- a/build/build_runm.sh
+++ b/build/build_runm.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+DEBUG=${DEBUG:-0}
+VERBOSE=${VERBOSE:-0}
+VERSION=$(git describe --tags --always --dirty)
+ROOT_DIR=$(cd $(dirname "$0")/.. && pwd)
+CMD_RUNM_DIR=$ROOT_DIR/cmd/runm
+BUILD_BIN_DIR=$ROOT_DIR/build/bin
+
+if [[ ! -d $BUILD_BIN_DIR ]]; then
+    mkdir $BUILD_BIN_DIR
+fi
+
+# Clean up any previously-built binary
+if [[ -f $BUILD_BIN_DIR/runm ]]; then
+    echo -n "Removing old runm binary ... "
+    rm $BUILD_BIN_DIR/runm
+    echo "ok."
+fi
+
+cd $CMD_RUNM_DIR
+
+echo -n "Building latest runm binary ... "
+CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o $BUILD_BIN_DIR/runm .
+echo "ok."

--- a/scripts/runm.sh
+++ b/scripts/runm.sh
@@ -6,6 +6,8 @@ VERSION=$(git describe --tags --always --dirty)
 ROOT_DIR=$(cd $(dirname "$0")/.. && pwd)
 SCRIPTS_DIR=$ROOT_DIR/scripts
 LIB_DIR=$SCRIPTS_DIR/lib
+BUILD_BIN_DIR=$ROOT_DIR/build/bin
+RUNM_BIN_PATH=$BUILD_BIN_DIR/runm
 
 source $LIB_DIR/common
 
@@ -13,14 +15,8 @@ if debug_enabled; then
     set -o xtrace
 fi
 
-source $SCRIPTS_DIR/service-up.sh
-
 runm_user=${RUNM_USER:-admin}
 runm_project=${RUNM_PROJECT:-proj0}
 runm_partition=${RUNM_PARTITION:-part0}
 
-docker run --rm --network host -v $ROOT_DIR/tests/data/:/tests/data \
-    -e RUNM_USER="$runm_user" \
-    -e RUNM_PROJECT="$runm_project" \
-    -e RUNM_PARTITION="$runm_partition" \
-    runm/runm:$VERSION "$@"
+RUNM_USER="$runm_user" RUNM_PROJECT="$runm_project" RUNM_PARTITION="$runm_partition" $RUNM_BIN_PATH "$@"


### PR DESCRIPTION
Modifies the build system to build the `runm` CLI tool in a local
$ROOT/build/bin directory instead of spinning up a Docker container with
just the runm client in it.

Changes the scripts/runm.sh script to call this locally-built CLI binary
instead of using a single-use Docker container for the runm client.

This resulted in dramatically quicker build and test script execution.

Before this patch:

```
[jaypipes@uberbox runmachine]$ time make build
...
real    0m53.645s
user    0m5.950s
sys     0m1.305s
[jaypipes@uberbox runmachine]$ time ./scripts/populate.sh
creating partition 'part0.yaml' ... 7384278d5dfd45f28ce2f65d999d8c0f
creating runm.compute provider definition for partition part0 ... ok
creating runm.storage.block provider definition for partition part0 ... ok
creating provider 'east1-row1-rack1-node1.yaml' ... fefe803b09cb456c99bbcdef11ecc0d9
creating provider 'east1-row1-rack2-node1.yaml' ... f864f06d50314c3f8eec5bb9e15d18df
creating provider 'east1-row2-rack1-node1.yaml' ... 8a07ec3f0ef24bb9a3b9ee086d030264
creating provider 'east1-row2-rack2-node1.yaml' ... f7a7998cb6c0438fa5774e90c5bc7c50
creating provider 'west1-row1-rack1-node1.yaml' ... 88925bac1e1749299e3d2ef55c79a20e
creating provider 'west1-row1-rack2-node1.yaml' ... 4b4a08941ed6463aa731fd2e16bb844d
creating provider 'west1-row2-rack1-node1.yaml' ... 33b124dd8e3949cd8a0675d6af50c711
creating provider 'west1-row2-rack2-node1.yaml' ... b1dfba041a0b4a209ee9e724c9719376

real    0m19.308s
user    0m12.945s
sys     0m2.074s
```

After this patch:

```
[jaypipes@uberbox runmachine]$ time make build
...
real    0m49.187s
user    0m38.931s
sys 0m3.839s
[jaypipes@uberbox runmachine]$ time ./scripts/populate.sh
creating partition 'part0.yaml' ... d784846122e649c4a5af11ef1a70d47b
creating runm.compute provider definition for partition part0 ... ok
creating runm.storage.block provider definition for partition part0 ... ok
creating provider 'east1-row1-rack1-node1.yaml' ... 7b1602e2a85643a1a4475fe5fce35a24
creating provider 'east1-row1-rack2-node1.yaml' ... cf0c37b2c1624d44849f57e066b223b1
creating provider 'east1-row2-rack1-node1.yaml' ... f0c3a2b7c68543bfabbce127e23497d3
creating provider 'east1-row2-rack2-node1.yaml' ... 72a25fc60ade4f85974122ea74bed605
creating provider 'west1-row1-rack1-node1.yaml' ... e8ec4a9d1f5a4419a0d68520c580ea0a
creating provider 'west1-row1-rack2-node1.yaml' ... 80666c6668f2484da0e3e7cab47eff5a
creating provider 'west1-row2-rack1-node1.yaml' ... 8720d36af01c487eb4e92e64a36fe26c
creating provider 'west1-row2-rack2-node1.yaml' ... 7aa35c59df034ea7b1efd7bec993fe4e

real    0m1.654s
user    0m1.143s
sys 0m0.360s
```

Fixes Issue #124