### PR TITLE
adds a reset.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,21 +55,21 @@ cover:
 		tail -n +2 coverage.out >> coverage-all.out;)
 	go tool cover -html=coverage-all.out -o=coverage-all.html
 
-build-base: test
+build-base:
 	@echo "building base Docker image ..."
-	docker build -q --label built-by=runmachine.io -t runm/base . -f cmd/Dockerfile
+	docker build -q --label built-by=runmachine.io -t runmachine.io/runmachine/base . -f cmd/Dockerfile
 
 build-metadata: build-base
 	@echo "building runm-metadata Docker image ..."
-	docker build -q --label built-by=runmachine.io -t runm/metadata:$(VERSION) . -f cmd/runm-metadata/Dockerfile
+	docker build -q --label built-by=runmachine.io -t runmachine.io/runmachine/metadata:$(VERSION) . -f cmd/runm-metadata/Dockerfile
 
 build-resource: build-base
 	@echo "building runm-resource Docker image ..."
-	docker build -q --label built-by=runmachine.io -t runm/resource:$(VERSION) . -f cmd/runm-resource/Dockerfile
+	docker build -q --label built-by=runmachine.io -t runmachine.io/runmachine/resource:$(VERSION) . -f cmd/runm-resource/Dockerfile
 
 build-api: build-base
 	@echo "building runm-api Docker image ..."
-	docker build -q --label built-by=runmachine.io -t runm/api:$(VERSION) . -f cmd/runm-api/Dockerfile
+	docker build -q --label built-by=runmachine.io -t runmachine.io/runmachine/api:$(VERSION) . -f cmd/runm-api/Dockerfile
 
 build-cli:
 	@echo "building runm CLI Docker image to $(BUILD_BIN_DIR)/runm ..."

--- a/cmd/runm-api/Dockerfile
+++ b/cmd/runm-api/Dockerfile
@@ -1,6 +1,6 @@
 # We use a multi-stage build, so we require Docker >=17.05 to build these
 # images
-FROM runm/base:latest as builder
+FROM runmachine.io/runmachine/base:latest as builder
 COPY . /go/src/github.com/runmachine-io/runmachine
 WORKDIR /go/src/github.com/runmachine-io/runmachine/cmd/runm-api
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o /bin/runm-api .

--- a/cmd/runm-metadata/Dockerfile
+++ b/cmd/runm-metadata/Dockerfile
@@ -1,6 +1,6 @@
 # We use a multi-stage build, so we require Docker >=17.05 to build these
 # images
-FROM runm/base:latest as builder
+FROM runmachine.io/runmachine/base:latest as builder
 COPY . /go/src/github.com/runmachine-io/runmachine
 WORKDIR /go/src/github.com/runmachine-io/runmachine/cmd/runm-metadata
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o /bin/runm-metadata .

--- a/cmd/runm-resource/Dockerfile
+++ b/cmd/runm-resource/Dockerfile
@@ -1,6 +1,6 @@
 # We use a multi-stage build, so we require Docker >=17.05 to build these
 # images
-FROM runm/base:latest as builder
+FROM runmachine.io/runmachine/base:latest as builder
 COPY . /go/src/github.com/runmachine-io/runmachine
 WORKDIR /go/src/github.com/runmachine-io/runmachine/cmd/runm-resource
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o /bin/runm-resource .

--- a/scripts/lib/container
+++ b/scripts/lib/container
@@ -55,3 +55,94 @@ container_is_running() {
     fi
     return 1
 }
+
+# Returns 0 if the container with the given name exists, else 1
+#
+# Note that a stopped container still exists on the system. So, while
+# container_is_running returns 1 for a stopped container, container_exists will
+# return 0 for a stopped container.
+#
+# Params:
+#
+#   $1: (required) name for the container
+#
+# Usage:
+#
+#   if container_is_running "etcd-example"; then
+#     echo "etcd-example container is running."
+#   else
+#     echo "etcd-example container is not running."
+#   fi
+container_exists() {
+    local __container_name="$1"
+
+    # Obviously all containers that are running also exist...
+    if container_is_running "$__container_name"; then
+        return 0
+    fi
+
+    __status=$(docker inspect --format='{{.State.Status}}' "$__container_name" 2>/dev/null )
+    if [ $? -eq 1 ]; then
+        return 1
+    fi
+    if [ $__status == "created" ]; then
+        return 0
+    fi
+    return 1
+}
+
+# Gracefully stops the container with the given name but does not destroy the
+# container.
+#
+# Params:
+#
+#   $1: (required) name for the container
+#
+# Usage:
+#
+#   container_stop "etcd-example"
+container_stop() {
+    local __container_name="$1"
+
+    if container_is_running "$__container_name"; then
+        docker stop "$__container_name" --time 2 1>/dev/null
+    fi
+}
+
+# Destroys the container with the given name.
+#
+# If the container with the given name is active, this function first attempts
+# to gracefully stop the container.
+#
+# Params:
+#
+#   $1: (required) name for the container
+#
+# Usage:
+#
+#   container_destroy "etcd-example"
+container_destroy() {
+    local __container_name="$1"
+
+    container_stop "$__container_name"
+    if container_exists "$__container_name"; then
+        docker rm "$__container_name"  1>/dev/null
+    fi
+}
+
+# Returns 0 if an image with the given name:tag exists, else 1
+#
+# Params:
+#
+#   $1: (required) name:tag for the image
+#
+# Usage:
+#
+#   if container_image_exists "runmachine.io/runmachine/meta:$VERSION"; then
+#     echo "runmachine.io/runmachine/meta:$VERSION image exists."
+#   fi
+container_image_exists() {
+    local __image_name_tag="$1"
+
+    docker image inspect "$__image_name_tag" >/dev/null 2>&1
+}

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Used for "resetting" a test environment back to a clean start state.
+#
+# This script stops the following containers if they are running:
+#  * runm-test-api
+#  * runm-test-metadata
+#  * runm-test-resource
+#  * runm-test-etcd
+#
+# And then proceeds to clear out the SQL database. We do not attempt to
+# stop/start the runm-test-mysql container because this container takes a
+# stupid long time to start up due to the init scripts used by the MySQL Docker
+# container. Instead, we just DROP and re-CREATE the database.
+#
+# When the runm-test-etcd container is re(started), the etcd service will be
+# re-created from scratch. When the runm-test-metadata service (re)starts, it
+# will create the necessary objects in the runm-test-etcd data store. When the
+# runm-test-resource service (re)starts, it will create all the necessary DB
+# tables in the database housed in the runm-test-mysql container.
+
+DEBUG=${DEBUG:-0}
+VERBOSE=${VERBOSE:-0}
+VERSION=$(git describe --tags --always --dirty)
+ROOT_DIR=$(cd $(dirname "$0")/.. && pwd)
+SCRIPTS_DIR=$ROOT_DIR/scripts
+LIB_DIR=$SCRIPTS_DIR/lib
+
+source $LIB_DIR/common
+
+check_is_installed docker
+
+source $LIB_DIR/container
+source $LIB_DIR/etcd
+source $LIB_DIR/mysql
+
+if debug_enabled; then
+    set -o xtrace
+fi
+
+ETCD_CONTAINER_NAME=${ETCD_CONTAINER_NAME:-"runm-test-etcd"}
+MYSQL_CONTAINER_NAME=${MYSQL_CONTAINER_NAME:-"runm-test-mysql"}
+METADATA_CONTAINER_NAME=${METADATA_CONTAINER_NAME:-"runm-test-metadata"}
+RESOURCE_CONTAINER_NAME=${RESOURCE_CONTAINER_NAME:-"runm-test-resource"}
+API_CONTAINER_NAME=${API_CONTAINER_NAME:-"runm-test-api"}
+
+if container_exists "$ETCD_CONTAINER_NAME"; then
+    inline_if_verbose "Destroying etcd container named $ETCD_CONTAINER_NAME... "
+    container_destroy "$ETCD_CONTAINER_NAME"
+    print_if_verbose "ok."
+fi
+
+if container_exists "$API_CONTAINER_NAME"; then
+    inline_if_verbose "Destroying runm-api container named $API_CONTAINER_NAME... "
+    container_destroy "$API_CONTAINER_NAME"
+    print_if_verbose "ok."
+fi
+
+if container_exists "$METADATA_CONTAINER_NAME"; then
+    inline_if_verbose "Destroying runm-metadata container named $METADATA_CONTAINER_NAME... "
+    container_destroy "$METADATA_CONTAINER_NAME"
+    print_if_verbose "ok."
+fi
+
+if container_exists "$RESOURCE_CONTAINER_NAME"; then
+    inline_if_verbose "Destroying runm-resource container named $RESOURCE_CONTAINER_NAME... "
+    container_destroy "$RESOURCE_CONTAINER_NAME"
+    print_if_verbose "ok."
+fi
+
+if ! container_is_running "$MYSQL_CONTAINER_NAME"; then
+    $SCRIPTS_DIR/start-mysql-container.sh "$MYSQL_CONTAINER_NAME"
+fi
+
+if ! container_get_ip "$MYSQL_CONTAINER_NAME" mysql_container_ip; then
+    echo "ERROR: could not get IP for mysql container"
+    exit 1
+fi
+
+inline_if_verbose "Dropping resource database ... "
+mysql -uroot -P3306 -h$mysql_container_ip -e "DROP DATABASE IF EXISTS runm_resource;"
+print_if_verbose "ok."
+
+$SCRIPTS_DIR/start-etcd-container.sh "$ETCD_CONTAINER_NAME"
+$SCRIPTS_DIR/start-runm-metadata-container.sh
+$SCRIPTS_DIR/start-runm-resource-container.sh
+$SCRIPTS_DIR/start-runm-api-container.sh
+$SCRIPTS_DIR/populate.sh

--- a/scripts/start-runm-api-container.sh
+++ b/scripts/start-runm-api-container.sh
@@ -19,6 +19,10 @@ if debug_enabled; then
     set -o xtrace
 fi
 
+if ! container_image_exists "runmachine.io/runmachine/api:$VERSION"; then
+    make build-api
+fi
+
 ETCD_CONTAINER_NAME=${ETCD_CONTAINER_NAME:-"runm-test-etcd"}
 MYSQL_CONTAINER_NAME=${MYSQL_CONTAINER_NAME:-"runm-test-mysql"}
 METADATA_CONTAINER_NAME=${METADATA_CONTAINER_NAME:-"runm-test-metadata"}
@@ -43,25 +47,7 @@ if ! container_get_ip "$MYSQL_CONTAINER_NAME" mysql_container_ip; then
     exit 1
 fi
 
-inline_if_verbose "Creating resource database ... "
-mysql -uroot -P3306 -h$mysql_container_ip -e "CREATE DATABASE IF NOT EXISTS runm_resource;"
-print_if_verbose "ok."
-
-if ! container_is_running "$METADATA_CONTAINER_NAME"; then
-    inline_if_verbose "Starting runm-metadata container named $METADATA_CONTAINER_NAME... "
-    docker run -d \
-        --rm \
-        -p 10002:10002 \
-        --name $METADATA_CONTAINER_NAME \
-        -e GSR_LOG_LEVEL=3 \
-        -e GSR_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
-        -e RUNM_LOG_LEVEL=3 \
-        -e RUNM_METADATA_STORAGE_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
-        -e RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX="$METADATA_CONTAINER_NAME" \
-        -e RUNM_METADATA_BOOTSTRAP_TOKEN="bootstrapme" \
-        runm/metadata:$VERSION >/dev/null 2>&1
-    print_if_verbose "ok."
-fi
+$SCRIPTS_DIR/start-runm-metadata-container.sh
 
 inline_if_verbose "Grabbing IP for $METADATA_CONTAINER_NAME ... "
 if container_get_ip "$METADATA_CONTAINER_NAME" metadata_container_ip; then
@@ -72,19 +58,7 @@ else
     exit 1
 fi
 
-if ! container_is_running "$RESOURCE_CONTAINER_NAME"; then
-    inline_if_verbose "Starting runm-resource container named $RESOURCE_CONTAINER_NAME... "
-    docker run -d \
-        --rm \
-        -p 10001:10001 \
-        --name $RESOURCE_CONTAINER_NAME \
-        -e GSR_LOG_LEVEL=3 \
-        -e GSR_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
-        -e RUNM_LOG_LEVEL=3 \
-        -e RUNM_RESOURCE_STORAGE_DSN="root:@tcp($mysql_container_ip:3306)/runm_resource" \
-        runm/resource:$VERSION >/dev/null 2>&1
-    print_if_verbose "ok."
-fi
+$SCRIPTS_DIR/start-runm-resource-container.sh
 
 inline_if_verbose "Grabbing IP for $RESOURCE_CONTAINER_NAME ... "
 if container_get_ip "$RESOURCE_CONTAINER_NAME" resource_container_ip; then
@@ -104,7 +78,7 @@ if ! container_is_running "$API_CONTAINER_NAME"; then
         -e GSR_LOG_LEVEL=3 \
         -e GSR_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
         -e RUNM_LOG_LEVEL=3 \
-        runm/api:$VERSION >/dev/null 2>&1
+        runmachine.io/runmachine/api:$VERSION >/dev/null 2>&1
     print_if_verbose "ok."
 fi
 

--- a/scripts/start-runm-metadata-container.sh
+++ b/scripts/start-runm-metadata-container.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+DEBUG=${DEBUG:-0}
+VERBOSE=${VERBOSE:-0}
+VERSION=$(git describe --tags --always --dirty)
+ROOT_DIR=$(cd $(dirname "$0")/.. && pwd)
+SCRIPTS_DIR=$ROOT_DIR/scripts
+LIB_DIR=$SCRIPTS_DIR/lib
+
+source $LIB_DIR/common
+
+check_is_installed docker
+
+source $LIB_DIR/container
+source $LIB_DIR/etcd
+source $LIB_DIR/mysql
+
+if debug_enabled; then
+    set -o xtrace
+fi
+
+if ! container_image_exists "runmachine.io/runmachine/metadata:$VERSION"; then
+    make build-metadata
+fi
+
+ETCD_CONTAINER_NAME=${ETCD_CONTAINER_NAME:-"runm-test-etcd"}
+METADATA_CONTAINER_NAME=${METADATA_CONTAINER_NAME:-"runm-test-metadata"}
+
+if ! container_is_running "$ETCD_CONTAINER_NAME"; then
+    $SCRIPTS_DIR/start-etcd-container.sh "$ETCD_CONTAINER_NAME"
+fi
+
+if ! container_get_ip "$ETCD_CONTAINER_NAME" etcd_container_ip; then
+    echo "ERROR: could not get IP for etcd container"
+    exit 1
+fi
+
+if ! container_is_running "$METADATA_CONTAINER_NAME"; then
+    inline_if_verbose "Starting runm-metadata container named $METADATA_CONTAINER_NAME ... "
+    docker run -d \
+        --rm \
+        -p 10002:10002 \
+        --name $METADATA_CONTAINER_NAME \
+        -e GSR_LOG_LEVEL=3 \
+        -e GSR_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
+        -e RUNM_LOG_LEVEL=3 \
+        -e RUNM_METADATA_STORAGE_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
+        -e RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX="$METADATA_CONTAINER_NAME" \
+        -e RUNM_METADATA_BOOTSTRAP_TOKEN="bootstrapme" \
+        runmachine.io/runmachine/metadata:$VERSION >/dev/null 2>&1
+    print_if_verbose "ok."
+fi
+
+inline_if_verbose "Grabbing IP for $METADATA_CONTAINER_NAME ... "
+if container_get_ip "$METADATA_CONTAINER_NAME" metadata_container_ip; then
+    print_if_verbose "ok."
+    print_if_verbose "runm-metadata running in container at ${metadata_container_ip}:10000."
+else
+    echo "ERROR: could not get IP for runm-metadata container"
+    exit 1
+fi

--- a/scripts/start-runm-resource-container.sh
+++ b/scripts/start-runm-resource-container.sh
@@ -19,6 +19,10 @@ if debug_enabled; then
     set -o xtrace
 fi
 
+if ! container_image_exists "runmachine.io/runmachine/resource:$VERSION"; then
+    make build-resource
+fi
+
 ETCD_CONTAINER_NAME=${ETCD_CONTAINER_NAME:-"runm-test-etcd"}
 MYSQL_CONTAINER_NAME=${MYSQL_CONTAINER_NAME:-"runm-test-mysql"}
 METADATA_CONTAINER_NAME=${METADATA_CONTAINER_NAME:-"runm-test-metadata"}
@@ -47,31 +51,6 @@ inline_if_verbose "Creating resource database ... "
 mysql -uroot -P3306 -h$mysql_container_ip -e "CREATE DATABASE IF NOT EXISTS runm_resource;"
 print_if_verbose "ok."
 
-if ! container_is_running "$METADATA_CONTAINER_NAME"; then
-    inline_if_verbose "Starting runm-metadata container named $METADATA_CONTAINER_NAME... "
-    docker run -d \
-        --rm \
-        -p 10002:10002 \
-        --name $METADATA_CONTAINER_NAME \
-        -e GSR_LOG_LEVEL=3 \
-        -e GSR_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
-        -e RUNM_LOG_LEVEL=3 \
-        -e RUNM_METADATA_STORAGE_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
-        -e RUNM_METADATA_STORAGE_ETCD_KEY_PREFIX="$METADATA_CONTAINER_NAME" \
-        -e RUNM_METADATA_BOOTSTRAP_TOKEN="bootstrapme" \
-        runm/metadata:$VERSION >/dev/null 2>&1
-    print_if_verbose "ok."
-fi
-
-inline_if_verbose "Grabbing IP for $METADATA_CONTAINER_NAME ... "
-if container_get_ip "$METADATA_CONTAINER_NAME" metadata_container_ip; then
-    print_if_verbose "ok."
-    print_if_verbose "runm-metadata running in container at ${metadata_container_ip}:10000."
-else
-    echo "ERROR: could not get IP for runm-metadata container"
-    exit 1
-fi
-
 if ! container_is_running "$RESOURCE_CONTAINER_NAME"; then
     inline_if_verbose "Starting runm-resource container named $RESOURCE_CONTAINER_NAME... "
     docker run -d \
@@ -82,7 +61,7 @@ if ! container_is_running "$RESOURCE_CONTAINER_NAME"; then
         -e GSR_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
         -e RUNM_LOG_LEVEL=3 \
         -e RUNM_RESOURCE_STORAGE_DSN="root:@tcp($mysql_container_ip:3306)/runm_resource" \
-        runm/resource:$VERSION >/dev/null 2>&1
+        runmachine.io/runmachine/resource:$VERSION >/dev/null 2>&1
     print_if_verbose "ok."
 fi
 
@@ -92,27 +71,5 @@ if container_get_ip "$RESOURCE_CONTAINER_NAME" resource_container_ip; then
     print_if_verbose "runm-resource running in container at ${resource_container_ip}:10001."
 else
     echo "ERROR: could not get IP for runm-resource container"
-    exit 1
-fi
-
-if ! container_is_running "$API_CONTAINER_NAME"; then
-    inline_if_verbose "Starting runm-api container named $API_CONTAINER_NAME... "
-    docker run -d \
-        --rm \
-        -p 10000:10000 \
-        --name $API_CONTAINER_NAME \
-        -e GSR_LOG_LEVEL=3 \
-        -e GSR_ETCD_ENDPOINTS="http://$etcd_container_ip:2379" \
-        -e RUNM_LOG_LEVEL=3 \
-        runm/api:$VERSION >/dev/null 2>&1
-    print_if_verbose "ok."
-fi
-
-inline_if_verbose "Grabbing IP for $API_CONTAINER_NAME ... "
-if container_get_ip "$API_CONTAINER_NAME" api_container_ip; then
-    print_if_verbose "ok."
-    print_if_verbose "runm-api running in container at ${api_container_ip}:10002."
-else
-    echo "ERROR: could not get IP for runm-api container"
     exit 1
 fi


### PR DESCRIPTION
Before we get into a functional test framework, I wanted to make it
easier and quicker to tear down and repopulate the test environment in
Docker. Therefore, I've created a scripts/reset.sh script that kills the
etcd, metadata, api and resource services and blanks out the MySQL DB,
then restarts all those services and re-populates the DB tables (due to
the auto-schema-migration that occurs when runm-resource is started).

Also included is a separation of the different container startup
functionality into their own scripts/start-runm-<SERVICE>-container.sh
scripts, which should help prevent copy/paste errors in the script code
in the future.