### PR TITLE
pin mysql image for testing at 5.7

### DIFF
--- a/scripts/lib/mysql
+++ b/scripts/lib/mysql
@@ -40,7 +40,7 @@ mysql_start_container() {
         --name $__container_name \
         -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
         -e MYSQL_ROOT_HOST="%" \
-        mysql/mysql-server:latest \
+        mysql/mysql-server:5.7 \
         --bind-address ${__node_addr} >/dev/null 2>&1
 
     # We need to wait until we see "/usr/sbin/mysqld: ready for connections" in


### PR DESCRIPTION
Learned a valuable lesson about never using :latest for an image...

The upstream mysql official container image changed its default
authentication plugin which causes the following failure:

ERROR 2059 (HY000): Authentication plugin 'caching_sha2_password' cannot
be loaded: /usr/lib/mysql/plugin/caching_sha2_password.so: cannot open
shared object file: No such file or directory

Solving this by pinning the MySQL version used in the runm-test-mysql
image to 5.7. Need to figure out what changed in the upstream image and
how to deal with the above error for MySQL 8+.