### PR TITLE
error when provider delete matches no records

### DIFF
--- a/pkg/api/server/errors.go
+++ b/pkg/api/server/errors.go
@@ -18,6 +18,10 @@ var (
 		codes.NotFound,
 		"object could not be found.",
 	)
+	ErrNoMatchingRecords = status.Errorf(
+		codes.NotFound,
+		"no matching records could be found.",
+	)
 	ErrSessionUserRequired = status.Errorf(
 		codes.FailedPrecondition,
 		"user is required in session.",

--- a/pkg/api/server/provider.go
+++ b/pkg/api/server/provider.go
@@ -31,6 +31,9 @@ func (s *Server) ProviderDelete(
 	if err != nil {
 		return nil, err
 	}
+	if len(provs) == 0 {
+		return nil, ErrNoMatchingRecords
+	}
 
 	uuids := make([]string, len(provs))
 	for x, prov := range provs {


### PR DESCRIPTION
Previously, when executing `runm provider delete <nonexistingid>`, we
would return a misleading and confusing error message:

Error: at least one UUID is required.

While the above was technically correct (we were attempting to call the
resource service's ProviderDeleteByUuids method with an empty slice of
UUIDs), it was confusing.

With this patch, we now return ErrNoMatchingRecords when no provider
records were found.

Note that this patch does not change the existing behaviour of `runm
provider delete` that will return success (with NumDeleted value of 1)
when the user calls `runm provider delete` with an existing identifier
as well as a non-existing identifier.

Issue #118